### PR TITLE
Make sure Admin / Block Editor script translations are loaded

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -52,6 +52,8 @@ class Assets {
 			true
 		);
 
+		wp_set_script_translations( "autoblue-{$name}-plugin-script", 'autoblue' );
+
 		if ( ! empty( $params ) && ! $autoblue_defined ) {
 			wp_add_inline_script( "autoblue-{$name}-plugin-script", 'const autoblue = ' . wp_json_encode( $params ), 'before' );
 			$autoblue_defined = true;


### PR DESCRIPTION
Hi @danielpost 

I've followed your progress from Bluesky about your plugin. It's an excellent idea and thanks a lot for sharing it!

Today I finally had a chance to test it. You did a great job, congratulations.

I ran into a few issues, so this PR is a suggestion to fix the most serious one imho: as I'm french and plan to use your plugin for my personal website I noticed the Admin part of your plugin wasnot being translated. Front end is fine.

The suggested PR is fixing this. I'll add 2 other PRs to suggest 2 other less serious fix.