### PR TITLE
Avoid `doing_it_wrong` warning caused by `rest_validate_value_from_schema()`

### DIFF
--- a/includes/Meta.php
+++ b/includes/Meta.php
@@ -57,10 +57,12 @@ class Meta {
 								],
 								'uri'      => [
 									'type'     => 'string',
+									'format'   => 'uri',
 									'required' => true,
 								],
 								'at_uri'   => [
-									'type' => 'uri',
+									'type'   => 'string',
+									'format' => 'uri',
 								],
 								'response' => [
 									'type' => 'string',

--- a/includes/Meta.php
+++ b/includes/Meta.php
@@ -56,7 +56,7 @@ class Meta {
 									'required' => true,
 								],
 								'uri'      => [
-									'type'     => 'uri',
+									'type'     => 'string',
 									'required' => true,
 								],
 								'at_uri'   => [


### PR DESCRIPTION
Steps to reproduce:

Open the Block editor making sure `WP_DEBUG` is true, you should see two warnings about `rest_validate_value_from_schema()` complaining. Looks like when the REST API sanitizes the `'autoblue_shares'` post meta its `uri` property is getting sanitized by `rest_validate_value_from_schema()` which does not support the `uri` type. Changing the type to `string` fixes the issue. I guess another way to fix this is to use a specific sanitization callback. I leave this at your expertise.