### PR TITLE
JSON is a field type not supported by 10.1.40-MariaDB

### DIFF
--- a/includes/Logging/Setup.php
+++ b/includes/Logging/Setup.php
@@ -26,8 +26,8 @@ class Setup {
 			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			level varchar(20) NOT NULL,
 			message text NOT NULL,
-			context JSON,
-			extra JSON,
+			context LONGTEXT,
+			extra LONGTEXT,
 			PRIMARY KEY  (id),
 			KEY created_at (created_at),
 			KEY level (level)


### PR DESCRIPTION
This is the first error I got when testing your plugin. My testing database server probably need an upgrade, but just in case I'm letting you know using the JSON field type prevented me to install the table you use to log Bluesky requests.

I've changed it for `LONGTEXT` which solved the issue for me. Feel free to close this issue if you think this old version of MariaDB doesn't need to be supported 😉 