### PR TITLE
Add codeception.yml to distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,7 @@
 .phpcs.xml
 .prettierrc.js
 README.md
+codeception.yml
 composer.lock
 package-lock.json
 package.json


### PR DESCRIPTION
This ensures `codeception.yml` will not be included in any releases.