### PR TITLE
Remove tests folder from dist

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,6 +4,7 @@
 /node_modules
 /src
 /bin
+/tests
 
 .distignore
 .editorconfig


### PR DESCRIPTION
0.0.5 accidentally included the `tests` folder in the release. Not a big deal, but unnecessary. This PR ensures the folder will be deleted in the next release and won't be included again.

IMO, not worth doing another release just to include this fix, since it doesn't affect anything and the increase in file size is insignificant.