### PR TITLE
Remove URI format from meta

### DIFF
--- a/includes/Meta.php
+++ b/includes/Meta.php
@@ -57,12 +57,7 @@ class Meta {
 								],
 								'uri'      => [
 									'type'     => 'string',
-									'format'   => 'uri',
 									'required' => true,
-								],
-								'at_uri'   => [
-									'type'   => 'string',
-									'format' => 'uri',
 								],
 								'response' => [
 									'type' => 'string',


### PR DESCRIPTION
This change was introduced in #7, but it appears that `format => 'uri'` fails on ATProto URIs, so we're removing it for now.

This was causing the `View on Bluesky` link after sharing to be empty because `uri` in the `autoblue_shares` meta field was empty.

I also removed `at_uri` because it is unused right now.