### PR TITLE
Fix encoding in excerpts

### DIFF
--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -143,7 +143,7 @@ class Bluesky {
 		 */
 		$message = apply_filters( 'autoblue/share_message', $message, $post_id );
 
-		$message = html_entity_decode( wp_strip_all_tags( $message ) );
+		$message = html_entity_decode( wp_strip_all_tags( $message ), ENT_QUOTES );
 		$message = ( new Utils\Text() )->trim_text( $message, 300 );
 
 		$body = [
@@ -158,8 +158,8 @@ class Bluesky {
 					'$type'    => 'app.bsky.embed.external',
 					'external' => [
 						'uri'         => get_permalink( $post->ID ),
-						'title'       => html_entity_decode( get_the_title( $post->ID ), ENT_QUOTES, 'UTF-8' ),
-						'description' => $excerpt,
+						'title'       => html_entity_decode( get_the_title( $post->ID ), ENT_QUOTES ),
+						'description' => html_entity_decode( wp_strip_all_tags( $excerpt ), ENT_QUOTES ),
 					],
 				],
 			],

--- a/includes/Utils/Text.php
+++ b/includes/Utils/Text.php
@@ -23,7 +23,7 @@ class Text {
 			return '';
 		}
 
-		$last_space = strrpos( $trimmed_string, ' ' );
+		$last_space = grapheme_strrpos( $trimmed_string, ' ' );
 
 		if ( $last_space !== false ) {
 			$trimmed_string = grapheme_substr( $trimmed_string, 0, $last_space );


### PR DESCRIPTION
This PR fixes HTML entity encoding in excerpt so that they get rendered correctly. Also fixes a tiny bug in the `trim_text` method that would cause text to be too long in some edge cases.