### PR TITLE
Make release script switch to new branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,20 @@ Autoblue uses the [10up/action-wordpress-plugin-deploy](https://github.com/10up/
 To release a new version, follow these steps:
 
 1. Switch to the `main` branch and make sure all changes are merged into it.
-2. Run `bin/release.sh <version>` to create a new release. Replace `<version>` with the new version number.
+2. Run `bin/release.sh <version>` to create a new release. Replace `<version>` with the new version number. This creates a new branch and updates the changelog and version numbers.
 3. Check the changelog in `readme.txt` and make changes if required.
-4. Commit the changes and push them to the repository.
+4. Commit the changes, create a PR to merge the release branch into `main`, and merge the PR.
 5. Create a new release on GitHub with the new version number, tag, and the changelog entry.
 6. The GitHub Action will automatically deploy the new version to the WordPress.org plugin repository.
+7. Add a new changelog entry on the [Autoblue changelog page](https://autoblue.co/changelog/) for the new version.
 
 ### Updating assets or readme without creating a new release
 
 To update the assets (like screenshots) or readme without creating a new release (e.g. when updating the `Tested up to` line), follow these steps:
 
-1. Checkout the `main` branch.
+1. Create a new branch from `main`.
 2. Update the assets in the `assets` directory (if required).
 3. Update `readme.txt` with new information (if required).
-4. Commit the changes and push them to the repository.
+4. Create a PR with the changes and merge it into `main`.
 
 The changes will be automatically deployed to the WordPress.org plugin repository by the [10up/action-wordpress-plugin-asset-update](https://github.com/10up/action-wordpress-plugin-asset-update) GitHub Action.

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -55,10 +55,22 @@ check_prerequisites() {
 		exit 1
 	fi
 
-	# if [[ -n "$(git status --porcelain)" ]]; then
-	# 	echo "Error: Working directory not clean, make sure you're working from a clean checkout and try again."
-	# 	exit 1
-	# fi
+	if [[ -n "$(git status --porcelain)" ]]; then
+		echo "Error: Working directory not clean, make sure you're working from a clean checkout and try again."
+		exit 1
+	fi
+}
+
+checkout_branch() {
+	local new_version=$1
+	local branch_name="release/v$new_version"
+
+	if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+		echo "Error: Branch $branch_name already exists"
+		exit 1
+	fi
+
+	git checkout -b "$branch_name"
 }
 
 update_files() {
@@ -108,6 +120,7 @@ main() {
 		exit 1
 	fi
 
+	checkout_branch "$new_version"
 	validate_version "$new_version" "$prev_version"
 	update_files "$new_version" "$prev_version"
 


### PR DESCRIPTION
Small PR that updates the `bin/release.sh` script to create a new branch from `main` with the correct version number.