### PR TITLE
Add support for self-hosted PDS

### DIFF
--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -54,7 +54,7 @@ class Bluesky {
 	/**
 	 * @return array<string,mixed>|false
 	 */
-	private function upload_image( int $image_id, string $access_token ) {
+	private function upload_image( int $image_id, string $access_token, string $did ) {
 		if ( ! $image_id || ! $access_token ) {
 			return false;
 		}
@@ -89,7 +89,7 @@ class Bluesky {
 			return false;
 		}
 
-		$blob = $this->api_client->upload_blob( $image_blob, $mime_type, $access_token );
+		$blob = $this->api_client->upload_blob( $image_blob, $mime_type, $access_token, $did );
 
 		if ( is_wp_error( $blob ) ) {
 			$this->log->error( __( 'Skipping image: Failed to upload image with ID `{attachment_id}` to Bluesky:', 'autoblue' ) . ' ' . $blob->get_error_message(), [ 'attachment_id' => $image_id ] );
@@ -173,14 +173,14 @@ class Bluesky {
 
 		$image_blob = false;
 		if ( has_post_thumbnail( $post->ID ) ) {
-			$image_blob = $this->upload_image( get_post_thumbnail_id( $post->ID ), $connection['access_jwt'] ); // @phpstan-ignore argument.type
+			$image_blob = $this->upload_image( get_post_thumbnail_id( $post->ID ), $connection['access_jwt'], $connection['did'] ); // @phpstan-ignore argument.type
 		}
 
 		if ( ! empty( $image_blob ) ) {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
-		$response = $this->api_client->create_record( $body, $connection['access_jwt'] );
+		$response = $this->api_client->create_record( $body, $connection['access_jwt'], $connection['did'] );
 
 		if ( is_wp_error( $response ) ) {
 			$this->log->error(

--- a/includes/Bluesky/API.php
+++ b/includes/Bluesky/API.php
@@ -119,6 +119,46 @@ class API {
 	}
 
 	/**
+	 * @return string|\WP_Error
+	 */
+	private function resolve_pds_endpoint( string $did ) {
+		if ( ! $did ) {
+			return new \WP_Error( 'autoblue_invalid_did', __( 'Invalid DID.', 'autoblue' ) );
+		}
+
+		$response = wp_safe_remote_get( ' https://plc.directory/' . $did );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $code ) {
+			return new \WP_Error( 'autoblue_did_resolve_error', __( 'Error resolving DID document.', 'autoblue' ) );
+		}
+
+		$body    = wp_remote_retrieve_body( $response );
+		$did_doc = json_decode( $body, true );
+
+		if ( ! $did_doc ) {
+			return new \WP_Error( 'autoblue_did_parse_error', __( 'Failed to parse DID document.', 'autoblue' ) );
+		}
+
+		if ( ! isset( $did_doc['service'] ) || ! is_array( $did_doc['service'] ) ) {
+			return new \WP_Error( 'autoblue_did_no_service', __( 'No service found in DID document.', 'autoblue' ) );
+		}
+
+		foreach ( $did_doc['service'] as $service ) {
+			if ( isset( $service['type'] ) && 'AtprotoPersonalDataServer' === $service['type'] && isset( $service['serviceEndpoint'] ) ) {
+				return $service['serviceEndpoint'];
+			}
+		}
+
+		return new \WP_Error( 'autoblue_did_no_pds', __( 'No PDS service found in DID document.', 'autoblue' ) );
+	}
+
+	/**
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function create_session( string $did, string $app_password ) {
@@ -126,7 +166,13 @@ class API {
 			return new \WP_Error( 'autoblue_invalid_did_or_password', __( 'Invalid DID or password.', 'autoblue' ) );
 		}
 
-		return $this->send_request(
+		$pds_endpoint = $this->resolve_pds_endpoint( $did );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
+		}
+
+		$result = $this->send_request(
 			[
 				'endpoint' => 'com.atproto.server.createSession',
 				'method'   => 'POST',
@@ -134,17 +180,25 @@ class API {
 					'identifier' => $did,
 					'password'   => $app_password,
 				],
-				'base_url' => self::BASE_URL,
+				'base_url' => $pds_endpoint,
 			]
 		);
+
+		return $result;
 	}
 
 	/**
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function refresh_session( string $refresh_jwt ) {
+	public function refresh_session( string $refresh_jwt, string $did ) {
 		if ( ! $refresh_jwt ) {
 			return new \WP_Error( 'autoblue_invalid_refresh_jwt', __( 'Invalid refresh JWT.', 'autoblue' ) );
+		}
+
+		$pds_endpoint = $this->resolve_pds_endpoint( $did );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
 		}
 
 		return $this->send_request(
@@ -155,7 +209,7 @@ class API {
 					'Content-Type'  => 'application/json',
 					'Authorization' => 'Bearer ' . $refresh_jwt,
 				],
-				'base_url' => self::BASE_URL,
+				'base_url' => $pds_endpoint,
 			]
 		);
 	}
@@ -164,9 +218,15 @@ class API {
 	 * @param array<string, mixed> $record
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function create_record( array $record, string $access_token ) {
+	public function create_record( array $record, string $access_token, string $did ) {
 		if ( ! $record || ! $access_token ) {
 			return new \WP_Error( 'autoblue_invalid_record_or_access_token', __( 'Invalid record or access token.', 'autoblue' ) );
+		}
+
+		$pds_endpoint = $this->resolve_pds_endpoint( $did );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
 		}
 
 		return $this->send_request(
@@ -177,7 +237,7 @@ class API {
 					'Authorization' => 'Bearer ' . $access_token,
 				],
 				'body'     => $record,
-				'base_url' => self::BASE_URL,
+				'base_url' => $pds_endpoint,
 			]
 		);
 	}
@@ -185,13 +245,19 @@ class API {
 	/**
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function upload_blob( string $blob, string $mime_type, string $access_token ) {
+	public function upload_blob( string $blob, string $mime_type, string $access_token, string $did ) {
 		if ( ! $blob || ! $mime_type ) {
 			return new \WP_Error( 'autoblue_invalid_blob_or_mime_type', __( 'Invalid blob or MIME type.', 'autoblue' ) );
 		}
 
 		if ( ! $access_token ) {
 			return new \WP_Error( 'autoblue_invalid_access_token', __( 'Invalid access token.', 'autoblue' ) );
+		}
+
+		$pds_endpoint = $this->resolve_pds_endpoint( $did );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
 		}
 
 		$data = $this->send_request(
@@ -203,7 +269,7 @@ class API {
 					'Content-Type'  => $mime_type,
 				],
 				'body'     => $blob,
-				'base_url' => self::BASE_URL,
+				'base_url' => $pds_endpoint,
 			]
 		);
 

--- a/includes/Bluesky/API.php
+++ b/includes/Bluesky/API.php
@@ -126,7 +126,14 @@ class API {
 			return new \WP_Error( 'autoblue_invalid_did', __( 'Invalid DID.', 'autoblue' ) );
 		}
 
-		$response = wp_safe_remote_get( ' https://plc.directory/' . $did );
+		$cache_key = 'autoblue_pds_endpoint_' . $did;
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$response = wp_safe_remote_get( 'https://plc.directory/' . $did );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -151,7 +158,11 @@ class API {
 
 		foreach ( $did_doc['service'] as $service ) {
 			if ( isset( $service['type'] ) && 'AtprotoPersonalDataServer' === $service['type'] && isset( $service['serviceEndpoint'] ) ) {
-				return $service['serviceEndpoint'];
+				$endpoint = $service['serviceEndpoint'];
+
+				set_transient( $cache_key, $endpoint, DAY_IN_SECONDS );
+
+				return $endpoint;
 			}
 		}
 

--- a/includes/ConnectionsManager.php
+++ b/includes/ConnectionsManager.php
@@ -96,7 +96,9 @@ class ConnectionsManager {
 		}
 
 		update_option( self::OPTION_KEY, $filtered_connections );
+
 		delete_transient( $this->get_transient_key( $did ) );
+		delete_transient( 'autoblue_pds_endpoint_' . $did );
 
 		$this->log->info( __( 'Connection with DID `{did}` deleted.', 'autoblue' ), [ 'did' => $did ] );
 

--- a/includes/ConnectionsManager.php
+++ b/includes/ConnectionsManager.php
@@ -155,7 +155,7 @@ class ConnectionsManager {
 			return new \WP_Error( 'autoblue_connection_not_found', __( 'Connection not found.', 'autoblue' ) );
 		}
 
-		$response = $this->api_client->refresh_session( $connection['refresh_jwt'] );
+		$response = $this->api_client->refresh_session( $connection['refresh_jwt'], $did );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/tests/wpunit/Bluesky/APITest.php
+++ b/tests/wpunit/Bluesky/APITest.php
@@ -72,52 +72,110 @@ class APITest extends WPTestCase {
 	}
 
 	public function test_create_session_with_valid_credentials() {
+		$request_count = 0;
+
 		add_filter(
 			'pre_http_request',
-			fn () => [
-				'response' => [ 'code' => 200 ],
-				'body'     => wp_json_encode(
-					[
-						'accessJwt'  => 'test-jwt-token',
-						'refreshJwt' => 'test-refresh-token',
-					]
-				),
-			],
+			function ( $response, $parsed_args, $url ) use ( &$request_count ) {
+				$request_count++;
+
+				if ( strpos( $url, 'plc.directory' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'id'      => 'did:plc:testuser123',
+								'service' => [
+									[
+										'id'              => '#atproto_pds',
+										'type'            => 'AtprotoPersonalDataServer',
+										'serviceEndpoint' => 'https://bsky.social',
+									],
+								],
+							]
+						),
+					];
+				}
+
+				if ( strpos( $url, 'createSession' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'accessJwt'  => 'test-jwt-token',
+								'refreshJwt' => 'test-refresh-token',
+							]
+						),
+					];
+				}
+
+				return $response;
+			},
+			10,
+			3
 		);
 
-		$result = $this->api->create_session( 'test-did', 'test-password' );
+		$result = $this->api->create_session( 'did:plc:testuser123', 'test-password' );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'accessJwt', $result );
 		$this->assertArrayHasKey( 'refreshJwt', $result );
+		$this->assertEquals( 2, $request_count, 'Should make 2 HTTP requests: PLC directory + createSession' );
 	}
 
 	public function test_upload_blob_with_invalid_inputs() {
-		$result = $this->api->upload_blob( '', '', '' );
+		$result = $this->api->upload_blob( '', '', '', '' );
 		$this->assertInstanceOf( WP_Error::class, $result );
 	}
 
 	public function test_upload_blob_with_valid_inputs() {
 		add_filter(
 			'pre_http_request',
-			fn () => [
-				'response' => [ 'code' => 200 ],
-				'body'     => wp_json_encode(
-					[
-						'blob' => [
-							'ref'      => [ '$link' => 'test-blob-ref' ],
-							'mimeType' => 'image/jpeg',
-							'size'     => 1024,
-						],
-					]
-				),
-			],
+			function ( $response, $parsed_args, $url ) {
+				if ( strpos( $url, 'plc.directory' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'id'      => 'did:plc:testuser123',
+								'service' => [
+									[
+										'id'              => '#atproto_pds',
+										'type'            => 'AtprotoPersonalDataServer',
+										'serviceEndpoint' => 'https://bsky.social',
+									],
+								],
+							]
+						),
+					];
+				}
+
+				if ( strpos( $url, 'uploadBlob' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'blob' => [
+									'ref'      => [ '$link' => 'test-blob-ref' ],
+									'mimeType' => 'image/jpeg',
+									'size'     => 1024,
+								],
+							]
+						),
+					];
+				}
+
+				return $response;
+			},
+			10,
+			3
 		);
 
 		$result = $this->api->upload_blob(
 			'test-blob-data',
 			'image/jpeg',
-			'test-access-token'
+			'test-access-token',
+			'did:plc:testuser123'
 		);
 
 		$this->assertIsArray( $result );
@@ -174,6 +232,104 @@ class APITest extends WPTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'thread', $result );
+	}
+
+	public function test_create_session_with_self_hosted_pds() {
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				if ( strpos( $url, 'plc.directory' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'id'      => 'did:plc:testuser123',
+								'service' => [
+									[
+										'id'              => '#atproto_pds',
+										'type'            => 'AtprotoPersonalDataServer',
+										'serviceEndpoint' => 'https://example.com',
+									],
+								],
+							]
+						),
+					];
+				}
+
+				if ( strpos( $url, 'example.com' ) !== false && strpos( $url, 'createSession' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'accessJwt'  => 'self-hosted-jwt-token',
+								'refreshJwt' => 'self-hosted-refresh-token',
+							]
+						),
+					];
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = $this->api->create_session( 'did:plc:testuser123', 'test-password' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'accessJwt', $result );
+		$this->assertEquals( 'self-hosted-jwt-token', $result['accessJwt'] );
+	}
+
+	public function test_pds_resolution_with_missing_service() {
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				if ( strpos( $url, 'plc.directory' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'id'      => 'did:plc:testuser123',
+								'service' => [], // No services.
+							]
+						),
+					];
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = $this->api->create_session( 'did:plc:testuser123', 'test-password' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'autoblue_did_no_pds', $result->get_error_code() );
+	}
+
+	public function test_pds_resolution_with_plc_directory_error() {
+		add_filter(
+			'pre_http_request',
+			function ( $response, $parsed_args, $url ) {
+				if ( strpos( $url, 'plc.directory' ) !== false ) {
+					return [
+						'response' => [ 'code' => 404 ],
+						'body'     => wp_json_encode( [ 'error' => 'Not Found' ] ),
+					];
+				}
+
+				return $response;
+			},
+			10,
+			3
+		);
+
+		$result = $this->api->create_session( 'did:plc:nonexistent', 'test-password' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'autoblue_did_resolve_error', $result->get_error_code() );
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
This PR adds support for [self-hosted Bluesky PDS instances](https://github.com/bluesky-social/pds).

It accomplishes this by calling [plc.directory](https://web.plc.directory/) with the DID of the user account and looking at the related `serviceEndpoint` for the PDS. This way users do not have to enter a PDS manually when connecting an account, and Autoblue handles everything automatically.

PDS endpoints are cached for 24 hours (they don't really change often if at all), and the cache can be cleared earlier by reconnecting the account.