### PR TITLE
fix(share): surface silent share failures via cron

### DIFF
--- a/includes/Bluesky/API.php
+++ b/includes/Bluesky/API.php
@@ -312,6 +312,10 @@ class API {
 			return new \WP_Error( 'autoblue_api_error', $error . ': ' . $message );
 		}
 
+		if ( ! is_array( $data ) ) {
+			return new \WP_Error( 'autoblue_invalid_response', __( 'Invalid JSON response from Bluesky API.', 'autoblue' ) );
+		}
+
 		return $data;
 	}
 

--- a/includes/PostHandler.php
+++ b/includes/PostHandler.php
@@ -57,15 +57,10 @@ class PostHandler {
 			return;
 		}
 
-		// Don't run this when saving already published posts.
+		// Don't run this when saving already published posts. The block editor commonly
+		// fires `wp_after_insert_post` more than once per publish, so this branch is the
+		// expected no-op path — intentionally silent to avoid misleading log noise.
 		if ( $post_before && $post_before->post_status === 'publish' ) {
-			$this->log->debug(
-				__( 'Skipping share for post `{post_title}` with ID `{post_id}` because the post is already published.', 'autoblue' ),
-				[
-					'post_id'    => $post_id,
-					'post_title' => $post->post_title,
-				]
-			);
 			return;
 		}
 
@@ -124,7 +119,19 @@ class PostHandler {
 			]
 		);
 
-		$bluesky = new Bluesky();
-		$bluesky->share_to_bluesky( $post_id );
+		try {
+			$bluesky = new Bluesky();
+			$bluesky->share_to_bluesky( $post_id );
+		} catch ( \Throwable $e ) {
+			$this->log->error(
+				__( 'Share failed: Uncaught exception while sharing post with ID {post_id}: {message}', 'autoblue' ),
+				[
+					'post_id' => $post_id,
+					'message' => $e->getMessage(),
+					'file'    => $e->getFile(),
+					'line'    => $e->getLine(),
+				]
+			);
+		}
 	}
 }

--- a/includes/PostHandler.php
+++ b/includes/PostHandler.php
@@ -57,9 +57,7 @@ class PostHandler {
 			return;
 		}
 
-		// Don't run this when saving already published posts. The block editor commonly
-		// fires `wp_after_insert_post` more than once per publish, so this branch is the
-		// expected no-op path — intentionally silent to avoid misleading log noise.
+		// Don't run this when saving already published posts.
 		if ( $post_before && $post_before->post_status === 'publish' ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

Posts could silently fail to share to Bluesky after the `"Processing share for post"` log line, with no error logged in the Autoblue log. This PR makes the failure visible (and removes a misleading log line that customers read as a failure even when nothing was wrong).

Three changes:

- **`includes/Bluesky/API.php`** — `send_request` now returns a `WP_Error` when the response body cannot be decoded into an array (e.g. empty body or non-JSON 200 response from a proxy/CDN). Previously it returned `null`, which propagated into `ConnectionsManager::refresh_tokens` and triggered a `TypeError` on `$response['accessJwt']` under PHP 8+. The cron worker died without logging, matching the customer report exactly.
- **`includes/PostHandler.php`** — wrap the `share_to_bluesky` call in `process_scheduled_share` in `try/catch (\Throwable)`. Any future fatal in the share path now surfaces in the Autoblue log with file/line context, instead of dying silently after `"Processing share for post"`.
- **`includes/PostHandler.php`** — remove the misleading `"Skipping share ... because the post is already published"` debug log. The block editor fires `wp_after_insert_post` more than once per publish (Gutenberg's normal double-write); this branch is the expected no-op path and should not produce log noise that customers read as a failure.

## Context

A customer reported these three entries appearing for every post and no Bluesky post showing up:

```
Processing share for post Day 79 of The100DayProject with ID 3271.
Skipping share for post Day 79 of The100DayProject with ID 3271 because the post is already published.
Scheduling share for post Day 79 of The100DayProject with ID 3271.
```

The "Skipping" line was a red herring (benign secondary `wp_after_insert_post` fire); the real bug was the share path dying silently between `"Processing"` and any of `share_to_bluesky`'s own error/success logs.

## Test plan

- [x] `vendor/bin/codecept run wpunit` — 33 tests, 84 assertions, all green
- [x] Local end-to-end via WP-CLI on a real WordPress install:
  - [x] Publish a new post → `"Scheduling share for post"` and `"Processing share for post"` log entries appear, followed (in our case) by an `error`-level `"Failed to refresh Bluesky connection tokens before sharing: ExpiredToken: Token has expired"` — no silent death
  - [x] Re-save the published post → zero new log entries (the silenced "already published" branch)
- [ ] Could not directly trigger the new `is_array` guard without mocking a 200-with-bad-body response — but the change is minimal and the failure mode it covers is the most likely cause of the original silent fatal

## Follow-up (not in this PR)

The customer's underlying issue is most likely an expired refresh token. Once this PR lands and surfaces the real error, we should also add user-facing indication on the settings page and on the new-post panel when the Bluesky connection's token is expired — currently the UI shows nothing and the share just fails.