### PR TITLE
chore(security): strip JWTs from public connection responses

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -73,7 +73,11 @@ class Assets {
 		$this->enqueue_style( 'editor' );
 	}
 
-	public function register_admin_assets(): void {
+	public function register_admin_assets( string $hook_suffix ): void {
+		if ( 'settings_page_autoblue' !== $hook_suffix ) {
+			return;
+		}
+
 		wp_enqueue_style( 'wp-components' );
 		wp_enqueue_style( 'dataviews' );
 		$this->enqueue_script(
@@ -92,8 +96,17 @@ class Assets {
 	private function get_initial_state(): array {
 		$current_page     = get_current_screen();
 		$refresh_accounts = $current_page && $current_page->id === 'settings_page_autoblue';
-		$connections      = ( new ConnectionsManager() )->get_all_connections( $refresh_accounts );
-		$logs             = ( new Logging\LogRepository() )->get_logs();
+		$is_settings_page = $current_page && $current_page->id === 'settings_page_autoblue';
+		$connections      = ( new ConnectionsManager() )->get_public_connections( $refresh_accounts );
+		$logs             = $is_settings_page ? ( new Logging\LogRepository() )->get_logs() : [
+			'data'       => [],
+			'pagination' => [
+				'page'        => 1,
+				'per_page'    => 10,
+				'total_items' => 0,
+				'total_pages' => 0,
+			],
+		];
 
 		return [
 			'accounts' => [

--- a/includes/ConnectionsManager.php
+++ b/includes/ConnectionsManager.php
@@ -126,6 +126,19 @@ class ConnectionsManager {
 	}
 
 	/**
+	 * @return array<string,mixed>|null
+	 */
+	public function get_public_connection_by_did( string $did, bool $force_refresh = false ): ?array {
+		$connection = $this->get_connection_by_did( $did, $force_refresh );
+
+		if ( ! $connection ) {
+			return null;
+		}
+
+		return $this->get_public_connection_data( $connection );
+	}
+
+	/**
 	 * @return array<int,array<string,mixed>>
 	 */
 	public function get_all_connections( bool $force_refresh = false ): array {
@@ -145,6 +158,16 @@ class ConnectionsManager {
 		}
 
 		return $connections;
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function get_public_connections( bool $force_refresh = false ): array {
+		return array_map(
+			[ $this, 'get_public_connection_data' ],
+			$this->get_all_connections( $force_refresh )
+		);
 	}
 
 	/**
@@ -248,6 +271,23 @@ class ConnectionsManager {
 			'handle' => sanitize_text_field( $profile['handle'] ?? '' ),
 			'name'   => sanitize_text_field( $profile['displayName'] ?? '' ),
 			'avatar' => esc_url_raw( $profile['avatar'] ?? '' ),
+		];
+	}
+
+	/**
+	 * @param array<string,mixed> $connection
+	 * @return array<string,mixed>
+	 */
+	private function get_public_connection_data( array $connection ): array {
+		$meta = $connection['meta'] ?? [];
+
+		return [
+			'did'  => sanitize_text_field( $connection['did'] ?? '' ),
+			'meta' => [
+				'handle' => sanitize_text_field( $meta['handle'] ?? '' ),
+				'name'   => sanitize_text_field( $meta['name'] ?? '' ),
+				'avatar' => esc_url_raw( $meta['avatar'] ?? '' ),
+			],
 		];
 	}
 

--- a/includes/Endpoints/ConnectionsController.php
+++ b/includes/Endpoints/ConnectionsController.php
@@ -59,7 +59,7 @@ class ConnectionsController extends WP_REST_Controller {
 	public function get_connections() {
 		$connections = new \Autoblue\ConnectionsManager();
 
-		return rest_ensure_response( $connections->get_all_connections() );
+		return rest_ensure_response( $connections->get_public_connections() );
 	}
 
 	/**
@@ -71,8 +71,13 @@ class ConnectionsController extends WP_REST_Controller {
 		$connections  = new \Autoblue\ConnectionsManager();
 		$did          = $request->get_param( 'did' );
 		$app_password = $request->get_param( 'app_password' );
+		$connection   = $connections->add_connection( $did, $app_password );
 
-		return rest_ensure_response( $connections->add_connection( $did, $app_password ) );
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		return rest_ensure_response( $connections->get_public_connection_by_did( $connection['did'], true ) );
 	}
 
 	/**

--- a/tests/wpunit/ConnectionsManagerTest.php
+++ b/tests/wpunit/ConnectionsManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests;
+
+use Autoblue\ConnectionsManager;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+class ConnectionsManagerTest extends WPTestCase {
+	private const DID = 'did:plc:testuser123';
+
+	public function test_public_connections_do_not_include_tokens(): void {
+		update_option(
+			'autoblue_connections',
+			[
+				[
+					'did'         => self::DID,
+					'access_jwt'  => 'mock-access-jwt',
+					'refresh_jwt' => 'mock-refresh-jwt',
+				],
+			]
+		);
+
+		set_transient(
+			'autoblue_connection_' . md5( self::DID ),
+			[
+				'handle' => 'test.bsky.social',
+				'name'   => 'Test User',
+				'avatar' => 'https://example.com/avatar.jpg',
+			],
+			DAY_IN_SECONDS
+		);
+
+		$connections = ( new ConnectionsManager() )->get_public_connections();
+
+		$this->assertCount( 1, $connections );
+		$this->assertSame( self::DID, $connections[0]['did'] );
+		$this->assertSame( 'test.bsky.social', $connections[0]['meta']['handle'] );
+		$this->assertArrayNotHasKey( 'access_jwt', $connections[0] );
+		$this->assertArrayNotHasKey( 'refresh_jwt', $connections[0] );
+	}
+
+	public function test_public_connection_by_did_does_not_include_tokens(): void {
+		update_option(
+			'autoblue_connections',
+			[
+				[
+					'did'         => self::DID,
+					'access_jwt'  => 'mock-access-jwt',
+					'refresh_jwt' => 'mock-refresh-jwt',
+				],
+			]
+		);
+
+		set_transient(
+			'autoblue_connection_' . md5( self::DID ),
+			[
+				'handle' => 'test.bsky.social',
+				'name'   => 'Test User',
+				'avatar' => 'https://example.com/avatar.jpg',
+			],
+			DAY_IN_SECONDS
+		);
+
+		$connection = ( new ConnectionsManager() )->get_public_connection_by_did( self::DID );
+
+		$this->assertIsArray( $connection );
+		$this->assertSame( self::DID, $connection['did'] );
+		$this->assertArrayNotHasKey( 'access_jwt', $connection );
+		$this->assertArrayNotHasKey( 'refresh_jwt', $connection );
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'autoblue_connections' );
+		delete_transient( 'autoblue_connection_' . md5( self::DID ) );
+
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

The REST `GET /autoblue/v1/connections` endpoint and the admin's localized initial state both returned the **full** connection record — including `access_jwt` and `refresh_jwt`. Anything that could read the response or inspect `window.autoblue` could lift those tokens.

This PR introduces a "public" connection shape (`{ did, meta: { handle, name, avatar } }`) that omits both JWTs, and routes every UI/REST path through it.

- **`ConnectionsManager`** — adds `get_public_connections()`, `get_public_connection_by_did()`, and a private `get_public_connection_data()` helper. No changes to the underlying storage shape; just a filtered view.
- **`ConnectionsController`** — `GET /connections` and `POST /connections` now return public-shape data. `POST` also propagates `WP_Error` correctly instead of wrapping it in a successful response object.
- **`Assets`** — `register_admin_assets` early-returns unless `$hook_suffix === 'settings_page_autoblue'` (avoids enqueueing the admin bundle on unrelated screens), the localized initial state now uses `get_public_connections()`, and the logs payload is only built on the settings page.
- **Tests** — new `tests/wpunit/ConnectionsManagerTest.php` covers both public shapes and asserts tokens are absent.

## Test plan

- [x] `vendor/bin/codecept run wpunit` — 33 tests, 84 assertions, all green (includes the 2 new cases)
- [ ] Manual: load `admin.php?page=autoblue` and inspect `window.autoblue.initialState.accounts.items` — should contain `{ did, meta }` only, no JWTs
- [ ] Manual: `curl /wp-json/autoblue/v1/connections` (with nonce/auth) — same check