### PR TITLE
feat(connections): surface expired-token state in the admin UI

### DIFF
--- a/includes/ConnectionsManager.php
+++ b/includes/ConnectionsManager.php
@@ -30,11 +30,6 @@ class ConnectionsManager {
 	 * @return array<string,mixed>|\WP_Error The added connection with profile data or error object.
 	 */
 	public function add_connection( string $did, string $app_password ) {
-		if ( $this->connection_exists( $did ) ) {
-			$this->log->warning( __( 'Connection not added: Connection with DID `{did}` already exists.', 'autoblue' ), [ 'did' => $did ] );
-			return new \WP_Error( 'autoblue_connection_exists', __( 'Connection already exists.', 'autoblue' ) );
-		}
-
 		if ( ! $this->is_valid_did( $did ) ) {
 			$this->log->warning( __( 'Connection not added: Invalid DID: `{did}`', 'autoblue' ), [ 'did' => $did ] );
 			return new \WP_Error( 'autoblue_invalid_did', __( 'Invalid DID.', 'autoblue' ) );
@@ -52,13 +47,14 @@ class ConnectionsManager {
 			return $auth_response;
 		}
 
+		$is_reconnect   = $this->connection_exists( $did );
 		$new_connection = [
 			'did'         => sanitize_text_field( $did ),
 			'access_jwt'  => sanitize_text_field( $auth_response['accessJwt'] ),
 			'refresh_jwt' => sanitize_text_field( $auth_response['refreshJwt'] ),
 		];
 
-		$this->store_connection( $new_connection );
+		$this->store_connection( $new_connection, $is_reconnect );
 
 		$profile_data = $this->fetch_and_cache_profile( $new_connection['did'], true );
 
@@ -183,6 +179,9 @@ class ConnectionsManager {
 		$response = $this->api_client->refresh_session( $connection['refresh_jwt'], $did );
 
 		if ( is_wp_error( $response ) ) {
+			if ( $this->is_auth_error( $response ) ) {
+				$this->mark_needs_reauth( $did );
+			}
 			return $response;
 		}
 
@@ -249,13 +248,46 @@ class ConnectionsManager {
 		}
 
 		foreach ( $connections as $connection ) {
-			$this->refresh_tokens( $connection['did'] );
+			$result = $this->refresh_tokens( $connection['did'] );
+
+			if ( is_wp_error( $result ) ) {
+				$this->log->warning(
+					__( 'Scheduled token refresh failed for DID `{did}`: {message}', 'autoblue' ),
+					[
+						'did'     => $connection['did'],
+						'message' => $result->get_error_message(),
+					]
+				);
+			}
 		}
 	}
 
 	private function connection_exists( string $did ): bool {
 		$connections = get_option( self::OPTION_KEY, [] );
 		return in_array( $did, array_column( $connections, 'did' ), true );
+	}
+
+	private function is_auth_error( \WP_Error $error ): bool {
+		$message = strtolower( $error->get_error_message() );
+		foreach ( [ 'expiredtoken', 'invalidtoken', 'authenticationrequired', 'authrequired' ] as $needle ) {
+			if ( strpos( $message, $needle ) !== false ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function mark_needs_reauth( string $did ): void {
+		$connections = get_option( self::OPTION_KEY, [] );
+
+		foreach ( $connections as &$connection ) {
+			if ( $connection['did'] === $did ) {
+				$connection['needs_reauth'] = true;
+				break;
+			}
+		}
+
+		update_option( self::OPTION_KEY, $connections );
 	}
 
 	private function is_valid_did( string $did ): bool {
@@ -282,8 +314,9 @@ class ConnectionsManager {
 		$meta = $connection['meta'] ?? [];
 
 		return [
-			'did'  => sanitize_text_field( $connection['did'] ?? '' ),
-			'meta' => [
+			'did'          => sanitize_text_field( $connection['did'] ?? '' ),
+			'needs_reauth' => ! empty( $connection['needs_reauth'] ),
+			'meta'         => [
 				'handle' => sanitize_text_field( $meta['handle'] ?? '' ),
 				'name'   => sanitize_text_field( $meta['name'] ?? '' ),
 				'avatar' => esc_url_raw( $meta['avatar'] ?? '' ),

--- a/src/js/components/account-info/index.js
+++ b/src/js/components/account-info/index.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from 'react';
 import apiFetch from '@wordpress/api-fetch';
-import { Spinner, Button } from '@wordpress/components';
+import { Spinner, Button, Notice } from '@wordpress/components';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
 
@@ -61,20 +61,24 @@ const useAccountInfo = ( did, meta ) => {
 };
 
 const AccountInfo = ( {
-	account: { did, meta = {} },
+	account: { did, meta = {}, needs_reauth: needsReauth = false },
 	className,
 	onDelete = null,
 	deleteLabel = null,
+	onReconnect = null,
 	size = 'medium',
 } ) => {
 	const { userData, isLoading } = useAccountInfo( did, meta );
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 
+	const showReauthNotice = needsReauth && onReconnect;
+
 	className = clsx(
 		styles.wrapper,
 		className,
 		size === 'small' && styles.small,
-		size === 'large' && styles.large
+		size === 'large' && styles.large,
+		showReauthNotice && styles.needsReauth
 	);
 
 	if ( isLoading ) {
@@ -89,40 +93,70 @@ const AccountInfo = ( {
 
 	return (
 		<div className={ className }>
-			<div className={ styles.meta }>
-				<figure className={ styles.avatar }>
-					{ userData.avatar && (
-						<img
-							src={ userData.avatar }
-							alt={ userData.displayName }
-							style={ {
-								display: isImageLoaded ? 'block' : 'none',
-							} }
-							onLoad={ () => setIsImageLoaded( true ) }
-							onError={ () => setIsImageLoaded( false ) }
-						/>
-					) }
-				</figure>
-				<div className={ styles.info }>
-					<span className={ styles.name }>
-						{ userData.displayName }
-					</span>
-					<span className={ styles.handle }>
-						@{ userData.handle }
-					</span>
-				</div>
-			</div>
-			{ onDelete && (
-				<Button
-					icon={ ! deleteLabel ? 'no-alt' : undefined }
-					isDestructive
-					variant={ ! deleteLabel ? undefined : 'secondary' }
-					onClick={ onDelete }
-					label={ deleteLabel || __( 'Delete', 'autoblue' ) }
+			{ showReauthNotice && (
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className={ styles.notice }
 				>
-					{ deleteLabel || null }
-				</Button>
+					{ __(
+						'This connection has expired. Reconnect to keep sharing to Bluesky.',
+						'autoblue'
+					) }
+				</Notice>
 			) }
+			<div className={ styles.row }>
+				<div className={ styles.meta }>
+					<figure className={ styles.avatar }>
+						{ userData.avatar && (
+							<img
+								src={ userData.avatar }
+								alt={ userData.displayName }
+								style={ {
+									display: isImageLoaded ? 'block' : 'none',
+								} }
+								onLoad={ () => setIsImageLoaded( true ) }
+								onError={ () => setIsImageLoaded( false ) }
+							/>
+						) }
+					</figure>
+					<div className={ styles.info }>
+						<span className={ styles.name }>
+							{ userData.displayName }
+						</span>
+						<span className={ styles.handle }>
+							@{ userData.handle }
+						</span>
+					</div>
+				</div>
+				{ ( showReauthNotice || onDelete ) && (
+					<div className={ styles.actions }>
+						{ showReauthNotice && (
+							<Button
+								variant="primary"
+								onClick={ onReconnect }
+							>
+								{ __( 'Reconnect', 'autoblue' ) }
+							</Button>
+						) }
+						{ onDelete && (
+							<Button
+								icon={ ! deleteLabel ? 'no-alt' : undefined }
+								isDestructive
+								variant={
+									! deleteLabel ? undefined : 'secondary'
+								}
+								onClick={ onDelete }
+								label={
+									deleteLabel || __( 'Delete', 'autoblue' )
+								}
+							>
+								{ deleteLabel || null }
+							</Button>
+						) }
+					</div>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/src/js/components/account-info/styles.module.scss
+++ b/src/js/components/account-info/styles.module.scss
@@ -14,10 +14,8 @@
 	background-color: rgb(255, 255, 255);
 	background-color: #fff;
 	display: flex;
+	flex-direction: column;
 	gap: var(--gap-size);
-	justify-content: space-between;
-	align-items: center;
-	flex-wrap: wrap;
 	width: 100%;
 	box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px;
 	outline: none;
@@ -31,6 +29,25 @@
 		border-bottom-left-radius: 7px;
 		border-bottom-right-radius: 7px;
 	}
+}
+
+.row {
+	display: flex;
+	gap: var(--gap-size);
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.actions {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+
+.notice {
+	margin: 0 !important;
 }
 
 .meta {

--- a/src/js/components/account-list/index.js
+++ b/src/js/components/account-list/index.js
@@ -7,12 +7,14 @@ import { useState } from '@wordpress/element';
 import useAccounts from './../../hooks/use-accounts';
 import useWindowDimensions from '../../hooks/use-window-dimensions';
 import AccountInfo from './../account-info';
+import useNewAccountModal from './../new-account-modal';
 
 const AccountList = () => {
 	const { width } = useWindowDimensions();
 	const { accounts, isLoading, deleteAccount } = useAccounts();
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ accountToDisconnect, setAccountToDisconnect ] = useState( null );
+	const { renderModal, openModalForReconnect } = useNewAccountModal();
 
 	if ( isLoading ) {
 		return <Spinner />;
@@ -61,9 +63,12 @@ const AccountList = () => {
 					account={ account }
 					onDelete={ () => handleDisconnectClick( account ) }
 					deleteLabel={ __( 'Disconnect', 'autoblue' ) }
+					onReconnect={ () => openModalForReconnect( account ) }
 					size={ width > 500 ? 'large' : 'small' }
 				/>
 			) ) }
+
+			{ renderModal() }
 		</div>
 	);
 };

--- a/src/js/components/new-account-modal/index.js
+++ b/src/js/components/new-account-modal/index.js
@@ -83,7 +83,7 @@ const NewAccountModal = ( {
 					>
 						{ isReconnect
 							? __( 'Reconnect account', 'autoblue' )
-							: __( 'Connect Account', 'autoblue' ) }
+							: __( 'Connect account', 'autoblue' ) }
 					</Button>
 					{ status === 'loading' && <Spinner /> }
 				</HStack>

--- a/src/js/components/new-account-modal/index.js
+++ b/src/js/components/new-account-modal/index.js
@@ -82,7 +82,7 @@ const NewAccountModal = ( {
 						disabled={ status === 'loading' }
 					>
 						{ isReconnect
-							? __( 'Reconnect Account', 'autoblue' )
+							? __( 'Reconnect account', 'autoblue' )
 							: __( 'Connect Account', 'autoblue' ) }
 					</Button>
 					{ status === 'loading' && <Spinner /> }

--- a/src/js/components/new-account-modal/index.js
+++ b/src/js/components/new-account-modal/index.js
@@ -25,12 +25,17 @@ const NewAccountModal = ( {
 	onAddAccount,
 	status,
 	errorMessage,
+	isReconnect,
 } ) => {
 	if ( ! isOpen ) return null;
 
 	return (
 		<Modal
-			title={ __( 'Connect Bluesky account', 'autoblue' ) }
+			title={
+				isReconnect
+					? __( 'Reconnect Bluesky account', 'autoblue' )
+					: __( 'Connect Bluesky account', 'autoblue' )
+			}
 			onRequestClose={ onClose }
 			focusOnMount="firstContentElement"
 			size="medium"
@@ -39,7 +44,11 @@ const NewAccountModal = ( {
 				{ selectedAccount ? (
 					<AccountInfo
 						account={ selectedAccount }
-						onDelete={ () => onSelectAccount( null ) }
+						onDelete={
+							isReconnect
+								? null
+								: () => onSelectAccount( null )
+						}
 					/>
 				) : (
 					<AccountSearch onSelect={ onSelectAccount } />
@@ -72,7 +81,9 @@ const NewAccountModal = ( {
 						onClick={ onAddAccount }
 						disabled={ status === 'loading' }
 					>
-						{ __( 'Connect Account', 'autoblue' ) }
+						{ isReconnect
+							? __( 'Reconnect Account', 'autoblue' )
+							: __( 'Connect Account', 'autoblue' ) }
 					</Button>
 					{ status === 'loading' && <Spinner /> }
 				</HStack>
@@ -90,16 +101,28 @@ const NewAccountModal = ( {
 const useNewAccountModal = ( initialIsOpen = false ) => {
 	const [ isOpen, setIsOpen ] = useState( initialIsOpen );
 	const [ selectedAccount, setSelectedAccount ] = useState( null );
+	const [ isReconnect, setIsReconnect ] = useState( false );
 	const [ appPassword, setAppPassword ] = useState( '' );
 	const [ status, setStatus ] = useState( 'idle' );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const { addAccount } = useAccounts();
 
-	const openModal = () => setIsOpen( true );
+	const openModal = () => {
+		setIsReconnect( false );
+		setIsOpen( true );
+	};
+	const openModalForReconnect = ( account ) => {
+		setSelectedAccount( account );
+		setIsReconnect( true );
+		setIsOpen( true );
+	};
 	const closeModal = () => {
 		setIsOpen( false );
 		setSelectedAccount( null );
 		setAppPassword( '' );
+		setIsReconnect( false );
+		setStatus( 'idle' );
+		setErrorMessage( '' );
 	};
 
 	const handleAppPasswordChange = ( newAppPassword ) => {
@@ -150,6 +173,7 @@ const useNewAccountModal = ( initialIsOpen = false ) => {
 			onAddAccount={ handleAddAccount }
 			status={ status }
 			errorMessage={ errorMessage }
+			isReconnect={ isReconnect }
 		/>
 	);
 
@@ -157,6 +181,7 @@ const useNewAccountModal = ( initialIsOpen = false ) => {
 		renderModal,
 		isOpen,
 		openModal,
+		openModalForReconnect,
 		closeModal,
 	};
 };

--- a/src/js/components/share-panel/index.js
+++ b/src/js/components/share-panel/index.js
@@ -58,32 +58,36 @@ const SharePanel = () => {
 		} );
 	};
 
+	const hasBrokenConnection = accounts.some( ( a ) => a.needs_reauth );
+	const effectiveIsEnabled = isEnabled && ! hasBrokenConnection;
+
 	return (
 		<VStack spacing={ 3 }>
+			{ hasBrokenConnection && (
+				<Notice status="warning" isDismissible={ false }>
+					{ createInterpolateElement(
+						__(
+							'Your Bluesky connection has expired. <a>Reconnect in Settings →</a>',
+							'autoblue'
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a href="admin.php?page=autoblue" />
+							),
+						}
+					) }
+				</Notice>
+			) }
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Share to Bluesky', 'autoblue' ) }
-				checked={ isEnabled }
+				checked={ effectiveIsEnabled }
 				onChange={ setIsEnabled }
+				disabled={ hasBrokenConnection }
 			/>
-			{ isEnabled && (
+			{ effectiveIsEnabled && (
 				<>
-					{ accounts.some( ( a ) => a.needs_reauth ) && (
-						<Notice status="warning" isDismissible={ false }>
-							{ createInterpolateElement(
-								__(
-									'Your Bluesky connection has expired. <a>Reconnect in Settings →</a>',
-									'autoblue'
-								),
-								{
-									a: (
-										// eslint-disable-next-line jsx-a11y/anchor-has-content
-										<a href="admin.php?page=autoblue" />
-									),
-								}
-							) }
-						</Notice>
-					) }
 					<TextareaControl
 						__nextHasNoMarginBottom
 						label={ __( 'Message', 'autoblue' ) }

--- a/src/js/components/share-panel/index.js
+++ b/src/js/components/share-panel/index.js
@@ -1,10 +1,12 @@
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import {
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	ToggleControl,
 	TextareaControl,
 	BaseControl,
 	Button,
+	Notice,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import AccountInfo from './../account-info';
@@ -66,6 +68,22 @@ const SharePanel = () => {
 			/>
 			{ isEnabled && (
 				<>
+					{ accounts.some( ( a ) => a.needs_reauth ) && (
+						<Notice status="warning" isDismissible={ false }>
+							{ createInterpolateElement(
+								__(
+									'Your Bluesky connection has expired. <a>Reconnect in Settings →</a>',
+									'autoblue'
+								),
+								{
+									a: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a href="admin.php?page=autoblue" />
+									),
+								}
+							) }
+						</Notice>
+					) }
 					<TextareaControl
 						__nextHasNoMarginBottom
 						label={ __( 'Message', 'autoblue' ) }

--- a/src/js/store/reducers/accounts.js
+++ b/src/js/store/reducers/accounts.js
@@ -11,11 +11,20 @@ export default function accounts( state = DEFAULT_STATE, action ) {
 				...state,
 				items: action.accounts,
 			};
-		case ADD_ACCOUNT:
+		case ADD_ACCOUNT: {
+			const existingIndex = state.items.findIndex(
+				( item ) => item.did === action.account.did
+			);
+			if ( existingIndex !== -1 ) {
+				const items = [ ...state.items ];
+				items[ existingIndex ] = action.account;
+				return { ...state, items };
+			}
 			return {
 				...state,
 				items: [ ...state.items, action.account ],
 			};
+		}
 		case DELETE_ACCOUNT:
 			return {
 				...state,

--- a/tests/wpunit/ConnectionsManagerTest.php
+++ b/tests/wpunit/ConnectionsManagerTest.php
@@ -8,18 +8,10 @@ use lucatume\WPBrowser\TestCase\WPTestCase;
 class ConnectionsManagerTest extends WPTestCase {
 	private const DID = 'did:plc:testuser123';
 
-	public function test_public_connections_do_not_include_tokens(): void {
-		update_option(
-			'autoblue_connections',
-			[
-				[
-					'did'         => self::DID,
-					'access_jwt'  => 'mock-access-jwt',
-					'refresh_jwt' => 'mock-refresh-jwt',
-				],
-			]
-		);
+	protected function setUp(): void {
+		parent::setUp();
 
+		set_transient( 'autoblue_pds_endpoint_' . self::DID, 'https://bsky.social', DAY_IN_SECONDS );
 		set_transient(
 			'autoblue_connection_' . md5( self::DID ),
 			[
@@ -29,6 +21,10 @@ class ConnectionsManagerTest extends WPTestCase {
 			],
 			DAY_IN_SECONDS
 		);
+	}
+
+	public function test_public_connections_do_not_include_tokens(): void {
+		$this->seed_connection();
 
 		$connections = ( new ConnectionsManager() )->get_public_connections();
 
@@ -40,26 +36,7 @@ class ConnectionsManagerTest extends WPTestCase {
 	}
 
 	public function test_public_connection_by_did_does_not_include_tokens(): void {
-		update_option(
-			'autoblue_connections',
-			[
-				[
-					'did'         => self::DID,
-					'access_jwt'  => 'mock-access-jwt',
-					'refresh_jwt' => 'mock-refresh-jwt',
-				],
-			]
-		);
-
-		set_transient(
-			'autoblue_connection_' . md5( self::DID ),
-			[
-				'handle' => 'test.bsky.social',
-				'name'   => 'Test User',
-				'avatar' => 'https://example.com/avatar.jpg',
-			],
-			DAY_IN_SECONDS
-		);
+		$this->seed_connection();
 
 		$connection = ( new ConnectionsManager() )->get_public_connection_by_did( self::DID );
 
@@ -69,9 +46,119 @@ class ConnectionsManagerTest extends WPTestCase {
 		$this->assertArrayNotHasKey( 'refresh_jwt', $connection );
 	}
 
+	public function test_public_connection_data_includes_needs_reauth(): void {
+		$this->seed_connection( [ 'needs_reauth' => true ] );
+
+		$connections = ( new ConnectionsManager() )->get_public_connections();
+
+		$this->assertTrue( $connections[0]['needs_reauth'] );
+	}
+
+	public function test_public_connection_data_defaults_needs_reauth_to_false(): void {
+		$this->seed_connection();
+
+		$connections = ( new ConnectionsManager() )->get_public_connections();
+
+		$this->assertFalse( $connections[0]['needs_reauth'] );
+	}
+
+	public function test_refresh_tokens_sets_needs_reauth_on_expired_token(): void {
+		$this->seed_connection();
+		$this->mock_refresh_session_response( 400, [
+			'error'   => 'ExpiredToken',
+			'message' => 'Token has been revoked',
+		] );
+
+		$result = ( new ConnectionsManager() )->refresh_tokens( self::DID );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$stored = get_option( 'autoblue_connections' );
+		$this->assertTrue( $stored[0]['needs_reauth'] );
+	}
+
+	public function test_refresh_tokens_does_not_set_needs_reauth_on_network_error(): void {
+		$this->seed_connection();
+		add_filter( 'pre_http_request', fn() => new \WP_Error( 'http_request_failed', 'Connection timed out' ), 10, 0 );
+
+		$result = ( new ConnectionsManager() )->refresh_tokens( self::DID );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$stored = get_option( 'autoblue_connections' );
+		$this->assertArrayNotHasKey( 'needs_reauth', $stored[0] );
+	}
+
+	public function test_successful_refresh_clears_needs_reauth(): void {
+		$this->seed_connection( [ 'needs_reauth' => true ] );
+		$this->mock_refresh_session_response( 200, [
+			'accessJwt'  => 'fresh-access',
+			'refreshJwt' => 'fresh-refresh',
+		] );
+
+		$result = ( new ConnectionsManager() )->refresh_tokens( self::DID );
+
+		$this->assertIsArray( $result );
+		$stored = get_option( 'autoblue_connections' );
+		$this->assertArrayNotHasKey( 'needs_reauth', $stored[0] );
+		$this->assertSame( 'fresh-access', $stored[0]['access_jwt'] );
+	}
+
+	public function test_add_connection_upserts_when_did_exists(): void {
+		$this->seed_connection( [ 'needs_reauth' => true ] );
+		add_filter( 'pre_http_request', function ( $response, $args, $url ) {
+			if ( strpos( $url, 'createSession' ) !== false ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode( [
+						'accessJwt'  => 'reconnect-access',
+						'refreshJwt' => 'reconnect-refresh',
+					] ),
+				];
+			}
+			return $response;
+		}, 10, 3 );
+
+		$result = ( new ConnectionsManager() )->add_connection( self::DID, 'aaaa-bbbb-cccc-dddd' );
+
+		$this->assertIsArray( $result );
+		$stored = get_option( 'autoblue_connections' );
+		$this->assertCount( 1, $stored, 'add_connection should upsert, not duplicate' );
+		$this->assertSame( 'reconnect-access', $stored[0]['access_jwt'] );
+		$this->assertArrayNotHasKey( 'needs_reauth', $stored[0] );
+	}
+
+	private function seed_connection( array $extra = [] ): void {
+		update_option(
+			'autoblue_connections',
+			[
+				array_merge(
+					[
+						'did'         => self::DID,
+						'access_jwt'  => 'mock-access-jwt',
+						'refresh_jwt' => 'mock-refresh-jwt',
+					],
+					$extra
+				),
+			]
+		);
+	}
+
+	private function mock_refresh_session_response( int $code, array $body ): void {
+		add_filter( 'pre_http_request', function ( $response, $args, $url ) use ( $code, $body ) {
+			if ( strpos( $url, 'refreshSession' ) !== false ) {
+				return [
+					'response' => [ 'code' => $code ],
+					'body'     => wp_json_encode( $body ),
+				];
+			}
+			return $response;
+		}, 10, 3 );
+	}
+
 	protected function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
 		delete_option( 'autoblue_connections' );
 		delete_transient( 'autoblue_connection_' . md5( self::DID ) );
+		delete_transient( 'autoblue_pds_endpoint_' . self::DID );
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/ConnectionsManagerTest.php
+++ b/tests/wpunit/ConnectionsManagerTest.php
@@ -64,10 +64,13 @@ class ConnectionsManagerTest extends WPTestCase {
 
 	public function test_refresh_tokens_sets_needs_reauth_on_expired_token(): void {
 		$this->seed_connection();
-		$this->mock_refresh_session_response( 400, [
-			'error'   => 'ExpiredToken',
-			'message' => 'Token has been revoked',
-		] );
+		$this->mock_refresh_session_response(
+			400,
+			[
+				'error'   => 'ExpiredToken',
+				'message' => 'Token has been revoked',
+			]
+		);
 
 		$result = ( new ConnectionsManager() )->refresh_tokens( self::DID );
 
@@ -89,10 +92,13 @@ class ConnectionsManagerTest extends WPTestCase {
 
 	public function test_successful_refresh_clears_needs_reauth(): void {
 		$this->seed_connection( [ 'needs_reauth' => true ] );
-		$this->mock_refresh_session_response( 200, [
-			'accessJwt'  => 'fresh-access',
-			'refreshJwt' => 'fresh-refresh',
-		] );
+		$this->mock_refresh_session_response(
+			200,
+			[
+				'accessJwt'  => 'fresh-access',
+				'refreshJwt' => 'fresh-refresh',
+			]
+		);
 
 		$result = ( new ConnectionsManager() )->refresh_tokens( self::DID );
 
@@ -104,18 +110,25 @@ class ConnectionsManagerTest extends WPTestCase {
 
 	public function test_add_connection_upserts_when_did_exists(): void {
 		$this->seed_connection( [ 'needs_reauth' => true ] );
-		add_filter( 'pre_http_request', function ( $response, $args, $url ) {
-			if ( strpos( $url, 'createSession' ) !== false ) {
-				return [
-					'response' => [ 'code' => 200 ],
-					'body'     => wp_json_encode( [
-						'accessJwt'  => 'reconnect-access',
-						'refreshJwt' => 'reconnect-refresh',
-					] ),
-				];
-			}
-			return $response;
-		}, 10, 3 );
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) {
+				if ( strpos( $url, 'createSession' ) !== false ) {
+					return [
+						'response' => [ 'code' => 200 ],
+						'body'     => wp_json_encode(
+							[
+								'accessJwt'  => 'reconnect-access',
+								'refreshJwt' => 'reconnect-refresh',
+							]
+						),
+					];
+				}
+				return $response;
+			},
+			10,
+			3
+		);
 
 		$result = ( new ConnectionsManager() )->add_connection( self::DID, 'aaaa-bbbb-cccc-dddd' );
 
@@ -143,15 +156,20 @@ class ConnectionsManagerTest extends WPTestCase {
 	}
 
 	private function mock_refresh_session_response( int $code, array $body ): void {
-		add_filter( 'pre_http_request', function ( $response, $args, $url ) use ( $code, $body ) {
-			if ( strpos( $url, 'refreshSession' ) !== false ) {
-				return [
-					'response' => [ 'code' => $code ],
-					'body'     => wp_json_encode( $body ),
-				];
-			}
-			return $response;
-		}, 10, 3 );
+		add_filter(
+			'pre_http_request',
+			function ( $response, $args, $url ) use ( $code, $body ) {
+				if ( strpos( $url, 'refreshSession' ) !== false ) {
+					return [
+						'response' => [ 'code' => $code ],
+						'body'     => wp_json_encode( $body ),
+					];
+				}
+				return $response;
+			},
+			10,
+			3
+		);
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## Summary

When a connection's Bluesky refresh JWT expires, every share attempt fails silently. The settings page kept showing the connection as healthy; the editor sidebar gave no indication that the next publish wouldn't reach Bluesky. This PR adds detection + persistence + UI:

- **`ConnectionsManager::refresh_tokens`** — if `refresh_session` returns a `WP_Error` whose message matches a known auth-failure shape (`ExpiredToken`, `InvalidToken`, `AuthenticationRequired`, `AuthRequired`), set `needs_reauth: true` on the stored connection. Successful refresh implicitly clears the flag (the whole record is rewritten).
- **`ConnectionsManager::add_connection`** — drop the "already exists" guard and upsert via `store_connection` so the Reconnect flow can reuse the same endpoint; successful upsert clears any prior `needs_reauth`.
- **`ConnectionsManager::refresh_all_connections`** (weekly cron) — log per-DID refresh outcomes; previously failures were swallowed silently.
- **`get_public_connection_data`** — include `needs_reauth` in the public shape.
- **Settings page (`AccountInfo` + `AccountList`)** — inline warning Notice + Reconnect button when `needs_reauth` is true.
- **`NewAccountModal`** — new `openModalForReconnect(account)` entry point; title and submit label switch to a Reconnect variant; the "remove selected account" affordance is suppressed in reconnect mode.
- **Editor sidebar (`SharePanel`)** — when any connected account has `needs_reauth`: warning Notice with a link to settings, the Share to Bluesky toggle is disabled and reads as off (underlying `autoblue_enabled` meta is preserved so the user's intent is restored after they reconnect), and the message/account list are hidden.

## Test plan

- [x] `vendor/bin/codecept run wpunit` — 39 tests / 97 assertions, all green (includes 6 new cases covering auth/non-auth refresh branches, successful-refresh clearing, `add_connection` upsert behavior, and the `needs_reauth` field in the public shape)
- [x] `npm run build` — clean build, no warnings
- [x] End-to-end via WP-CLI against a real expired connection:
  - `ConnectionsManager::refresh_tokens` returns `WP_Error('ExpiredToken: Token has expired')` and the stored connection now has `needs_reauth: true`
  - `GET /wp-json/autoblue/v1/connections` returns `[{did, needs_reauth: true, meta: {...}}]` (no JWTs)
  - `wp cron event run autoblue_refresh_connections` writes a `warning`-level log entry: `"Scheduled token refresh failed for DID ... : ExpiredToken: Token has expired"` (previously: no log)
- [ ] Manual settings-page check: load `admin.php?page=autoblue` — the expired account should show the warning Notice + Reconnect button
- [ ] Manual reconnect: click Reconnect → modal opens pre-selected → submit fresh app password → in-place update, `needs_reauth` clears, the warning disappears
- [ ] Manual editor check: open the block editor on any post — the warning Notice should be visible above the toggle, the toggle should be disabled and read as off, and the message/account list should be hidden

## Related

Companion to #42 (`fix(share): surface silent share failures via cron`) — that PR makes the failure visible in the log; this one closes the loop by making it visible in the UI before the user tries to publish.