### PR TITLE
feat(standard-site): publish posts as site.standard.document records

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -126,12 +126,12 @@ class Admin {
 					'schema' => [
 						'type'                 => 'object',
 						'properties'           => [
-							'name'                   => [ 'type' => [ 'string', 'null' ] ],
-							'description'            => [ 'type' => [ 'string', 'null' ] ],
-							'icon_id'                => [ 'type' => [ 'integer', 'null' ] ],
-							'theme_background'       => [ 'type' => [ 'string', 'null' ] ],
-							'theme_foreground'       => [ 'type' => [ 'string', 'null' ] ],
-							'theme_accent'           => [ 'type' => [ 'string', 'null' ] ],
+							'name'                    => [ 'type' => [ 'string', 'null' ] ],
+							'description'             => [ 'type' => [ 'string', 'null' ] ],
+							'icon_id'                 => [ 'type' => [ 'integer', 'null' ] ],
+							'theme_background'        => [ 'type' => [ 'string', 'null' ] ],
+							'theme_foreground'        => [ 'type' => [ 'string', 'null' ] ],
+							'theme_accent'            => [ 'type' => [ 'string', 'null' ] ],
 							'theme_accent_foreground' => [ 'type' => [ 'string', 'null' ] ],
 						],
 						'additionalProperties' => false,

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -126,9 +126,13 @@ class Admin {
 					'schema' => [
 						'type'                 => 'object',
 						'properties'           => [
-							'name'        => [ 'type' => [ 'string', 'null' ] ],
-							'description' => [ 'type' => [ 'string', 'null' ] ],
-							'icon_id'     => [ 'type' => [ 'integer', 'null' ] ],
+							'name'                   => [ 'type' => [ 'string', 'null' ] ],
+							'description'            => [ 'type' => [ 'string', 'null' ] ],
+							'icon_id'                => [ 'type' => [ 'integer', 'null' ] ],
+							'theme_background'       => [ 'type' => [ 'string', 'null' ] ],
+							'theme_foreground'       => [ 'type' => [ 'string', 'null' ] ],
+							'theme_accent'           => [ 'type' => [ 'string', 'null' ] ],
+							'theme_accent_foreground' => [ 'type' => [ 'string', 'null' ] ],
 						],
 						'additionalProperties' => false,
 					],

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -106,6 +106,39 @@ class Admin {
 
 		register_setting(
 			'autoblue',
+			'autoblue_publish_documents_enabled',
+			[
+				'type'              => 'boolean',
+				'description'       => __( 'Whether to publish posts as standard.site documents.', 'autoblue' ),
+				'show_in_rest'      => true,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
+		);
+
+		register_setting(
+			'autoblue',
+			'autoblue_publication_overrides',
+			[
+				'type'         => 'object',
+				'description'  => __( 'Per-field overrides for the standard.site publication record.', 'autoblue' ),
+				'show_in_rest' => [
+					'schema' => [
+						'type'                 => 'object',
+						'properties'           => [
+							'name'        => [ 'type' => [ 'string', 'null' ] ],
+							'description' => [ 'type' => [ 'string', 'null' ] ],
+							'icon_id'     => [ 'type' => [ 'integer', 'null' ] ],
+						],
+						'additionalProperties' => false,
+					],
+				],
+				'default'      => [],
+			],
+		);
+
+		register_setting(
+			'autoblue',
 			'autoblue_log_level',
 			[
 				'type'              => 'string',

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -108,6 +108,8 @@ class Assets {
 			],
 		];
 
+		$publication_record = get_option( 'autoblue_publication_record', [] );
+
 		return [
 			'accounts' => [
 				'items' => $connections,
@@ -115,6 +117,15 @@ class Assets {
 			'settings' => [
 				'enabled'            => get_option( 'autoblue_enabled', false ),
 				'availablePostTypes' => Utils::get_available_post_types(),
+				'standardSite'       => [
+					'isRootInstall' => Utils::is_root_install(),
+					'publication'   => [
+						'url'          => untrailingslashit( home_url( '/' ) ),
+						'siteName'     => get_bloginfo( 'name' ),
+						'siteDesc'     => get_bloginfo( 'description' ),
+						'publishedUri' => isset( $publication_record['uri'] ) ? (string) $publication_record['uri'] : null,
+					],
+				],
 			],
 			'logs'     => [
 				'items'      => $logs['data'],

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -78,6 +78,7 @@ class Assets {
 			return;
 		}
 
+		wp_enqueue_media();
 		wp_enqueue_style( 'wp-components' );
 		wp_enqueue_style( 'dataviews' );
 		$this->enqueue_script(
@@ -109,6 +110,10 @@ class Assets {
 		];
 
 		$publication_record = get_option( 'autoblue_publication_record', [] );
+		$overrides          = get_option( 'autoblue_publication_overrides', [] );
+		$override_icon_id   = is_array( $overrides ) && ! empty( $overrides['icon_id'] ) ? (int) $overrides['icon_id'] : 0;
+		$override_icon_url  = $override_icon_id > 0 ? (string) wp_get_attachment_image_url( $override_icon_id, 'thumbnail' ) : '';
+		$site_icon_url      = (string) get_site_icon_url( 128 );
 
 		return [
 			'accounts' => [
@@ -120,10 +125,12 @@ class Assets {
 				'standardSite'       => [
 					'isRootInstall' => Utils::is_root_install(),
 					'publication'   => [
-						'url'          => untrailingslashit( home_url( '/' ) ),
-						'siteName'     => get_bloginfo( 'name' ),
-						'siteDesc'     => get_bloginfo( 'description' ),
-						'publishedUri' => isset( $publication_record['uri'] ) ? (string) $publication_record['uri'] : null,
+						'url'             => untrailingslashit( home_url( '/' ) ),
+						'siteName'        => get_bloginfo( 'name' ),
+						'siteDesc'        => get_bloginfo( 'description' ),
+						'siteIconUrl'     => $site_icon_url,
+						'iconOverrideUrl' => $override_icon_url,
+						'publishedUri'    => isset( $publication_record['uri'] ) ? (string) $publication_record['uri'] : null,
 					],
 				],
 			],

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -176,7 +176,34 @@ class Bluesky {
 			$image_blob = $this->upload_image( get_post_thumbnail_id( $post->ID ), $connection['access_jwt'], $connection['did'] ); // @phpstan-ignore argument.type
 		}
 
-		if ( ! empty( $image_blob ) ) {
+		// When standard.site publishing is on for this post, write the document FIRST
+		// and swap the bsky post's external link card for a record embed pointing at
+		// the document.
+		$publish_document = $this->should_publish_document_for( $post_id );
+		$document_ref     = null;
+
+		if ( $publish_document ) {
+			$document_ref = ( new Standard\Document( $this->api_client, $this->log ) )->publish(
+				$post_id,
+				null,
+				is_array( $image_blob ) ? $image_blob : null
+			);
+
+			if ( is_wp_error( $document_ref ) ) {
+				// Fall back to the regular link-card path if the document write failed.
+				$document_ref = null;
+			}
+		}
+
+		if ( is_array( $document_ref ) && ! empty( $document_ref['uri'] ) && ! empty( $document_ref['cid'] ) ) {
+			$body['record']['embed'] = [
+				'$type'  => 'app.bsky.embed.record',
+				'record' => [
+					'uri' => $document_ref['uri'],
+					'cid' => $document_ref['cid'],
+				],
+			];
+		} elseif ( ! empty( $image_blob ) ) {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
@@ -217,30 +244,13 @@ class Bluesky {
 			]
 		);
 
-		if ( $this->should_publish_document( $post_id, $response ) ) {
-			( new Standard\Document( $this->api_client, $this->log ) )->publish(
-				$post_id,
-				[
-					'uri' => (string) $response['uri'],
-					'cid' => (string) $response['cid'],
-				],
-				is_array( $image_blob ) ? $image_blob : null
-			);
-		}
-
 		return $share;
 	}
 
 	/**
-	 * Whether this share should also produce a standard.site document record.
-	 *
-	 * @param array<string,mixed> $bsky_response
+	 * Whether this post should also produce a standard.site document record.
 	 */
-	private function should_publish_document( int $post_id, array $bsky_response ): bool {
-		if ( empty( $bsky_response['uri'] ) || empty( $bsky_response['cid'] ) ) {
-			return false;
-		}
-
+	private function should_publish_document_for( int $post_id ): bool {
 		if ( ! Utils::is_standard_site_enabled() ) {
 			return false;
 		}

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -227,6 +227,18 @@ class Bluesky {
 			]
 		);
 
+		// Back-fill bskyPostRef on the document now that we know the bsky post's URI/CID.
+		if ( ! empty( $associated_refs ) && ! empty( $response['uri'] ) && ! empty( $response['cid'] ) ) {
+			( new Standard\Document( $this->api_client, $this->log ) )->update_bsky_ref(
+				$post_id,
+				[
+					'uri' => (string) $response['uri'],
+					'cid' => (string) $response['cid'],
+				],
+				is_array( $image_blob ) ? $image_blob : null
+			);
+		}
+
 		return $share;
 	}
 

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -180,17 +180,17 @@ class Bluesky {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
-		// If standard.site publishing is on for this post, write the document FIRST
-		// (so we know its URI + CID) and attach strongRefs to the bsky post's
-		// external embed via associatedRefs. The bsky post still looks like a
-		// normal link card to Bluesky users; standard.site-aware clients can
-		// follow the refs to the document and publication records.
-		$associated_refs = $this->build_associated_refs( $post_id, is_array( $image_blob ) ? $image_blob : null );
-		if ( ! empty( $associated_refs ) ) {
-			$body['record']['embed']['external']['associatedRefs'] = $associated_refs;
+		if ( $this->should_publish_document_for( $post_id ) ) {
+			$response = $this->create_post_with_document(
+				$post_id,
+				$post,
+				$connection,
+				$body['record'],
+				is_array( $image_blob ) ? $image_blob : null
+			);
+		} else {
+			$response = $this->api_client->create_record( $body, $connection['access_jwt'], $connection['did'] );
 		}
-
-		$response = $this->api_client->create_record( $body, $connection['access_jwt'], $connection['did'] );
 
 		if ( is_wp_error( $response ) ) {
 			$this->log->error(
@@ -227,18 +227,6 @@ class Bluesky {
 			]
 		);
 
-		// Back-fill bskyPostRef on the document now that we know the bsky post's URI/CID.
-		if ( ! empty( $associated_refs ) && ! empty( $response['uri'] ) && ! empty( $response['cid'] ) ) {
-			( new Standard\Document( $this->api_client, $this->log ) )->update_bsky_ref(
-				$post_id,
-				[
-					'uri' => (string) $response['uri'],
-					'cid' => (string) $response['cid'],
-				],
-				is_array( $image_blob ) ? $image_blob : null
-			);
-		}
-
 		return $share;
 	}
 
@@ -254,44 +242,91 @@ class Bluesky {
 	}
 
 	/**
-	 * If standard.site is enabled for this post, ensure the publication record
-	 * exists, write the document record (without bskyPostRef — we don't have
-	 * the bsky URI yet), and return strongRefs for both so the bsky post can
-	 * attach them via embed.external.associatedRefs.
+	 * Create the Bluesky post and standard.site document in one atomic write.
 	 *
-	 * @param array<string,mixed>|null $image_blob Optional reusable cover image blob.
-	 * @return array<int,array<string,mixed>>
+	 * The initial document cannot include bskyPostRef because the Bluesky post
+	 * CID is only known after the write. Once the atomic create succeeds, we
+	 * update the document with the document-side strongRef. The Bluesky post does
+	 * not point back at the document, avoiding an unstable CID cycle.
+	 *
+	 * @param array<string,mixed>      $connection
+	 * @param array<string,mixed>      $bsky_record
+	 * @param array<string,mixed>|null $image_blob
+	 * @return array<string,mixed>|\WP_Error
 	 */
-	private function build_associated_refs( int $post_id, ?array $image_blob ): array {
-		if ( ! $this->should_publish_document_for( $post_id ) ) {
-			return [];
+	private function create_post_with_document( int $post_id, \WP_Post $post, array $connection, array $bsky_record, ?array $image_blob ) {
+		$publication     = new Standard\Publication( $this->api_client, $this->log );
+		$publication_uri = $publication->ensure_exists_for_connection( $connection );
+		if ( is_wp_error( $publication_uri ) ) {
+			return $publication_uri;
 		}
 
-		$document    = new Standard\Document( $this->api_client, $this->log );
-		$publication = new Standard\Publication( $this->api_client, $this->log );
-
-		$doc_ref = $document->publish( $post_id, null, $image_blob );
-		if ( is_wp_error( $doc_ref ) || empty( $doc_ref['uri'] ) || empty( $doc_ref['cid'] ) ) {
-			return [];
+		$document = new Standard\Document( $this->api_client, $this->log, $publication );
+		$prepared = $document->prepare_record( $post_id, (string) $publication_uri, null, $image_blob );
+		if ( is_wp_error( $prepared ) ) {
+			return $prepared;
 		}
 
-		$refs = [
+		$result = $this->api_client->apply_writes(
 			[
-				'$type' => 'com.atproto.repo.strongRef',
-				'uri'   => $doc_ref['uri'],
-				'cid'   => $doc_ref['cid'],
+				[
+					'$type'      => 'com.atproto.repo.applyWrites#create',
+					'collection' => 'app.bsky.feed.post',
+					'rkey'       => $this->generate_rkey(),
+					'value'      => $bsky_record,
+				],
+				[
+					'$type'      => 'com.atproto.repo.applyWrites#create',
+					'collection' => 'site.standard.document',
+					'rkey'       => $prepared['rkey'],
+					'value'      => $prepared['record'],
+				],
 			],
-		];
+			$connection['access_jwt'],
+			$connection['did']
+		);
 
-		$pub_ref = $publication->get_strongref();
-		if ( $pub_ref ) {
-			$refs[] = [
-				'$type' => 'com.atproto.repo.strongRef',
-				'uri'   => $pub_ref['uri'],
-				'cid'   => $pub_ref['cid'],
-			];
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		return $refs;
+		$bsky_result = $result['results'][0] ?? [];
+		$doc_result  = $result['results'][1] ?? [];
+		if ( empty( $bsky_result['uri'] ) || empty( $bsky_result['cid'] ) || empty( $doc_result['uri'] ) || empty( $doc_result['cid'] ) ) {
+			return new \WP_Error( 'autoblue_invalid_apply_writes_response', __( 'The PDS did not return complete Bluesky and document record refs.', 'autoblue' ) );
+		}
+
+		$document->store_meta( $post_id, $doc_result, $prepared['rkey'] );
+
+		$update = $document->update_bsky_ref(
+			$post_id,
+			[
+				'uri' => (string) $bsky_result['uri'],
+				'cid' => (string) $bsky_result['cid'],
+			],
+			$image_blob,
+			$connection
+		);
+
+		if ( is_wp_error( $update ) ) {
+			$this->log->error(
+				__( 'Failed to add bskyPostRef to standard.site document for post `{post_title}` with ID `{post_id}`: {message}', 'autoblue' ),
+				[
+					'post_id'    => $post_id,
+					'post_title' => $post->post_title,
+					'message'    => $update->get_error_message(),
+				]
+			);
+		}
+
+		return [
+			'uri'         => (string) $bsky_result['uri'],
+			'cid'         => (string) $bsky_result['cid'],
+			'applyWrites' => $result,
+		];
+	}
+
+	private function generate_rkey(): string {
+		return 'ab' . strtolower( str_replace( '-', '', wp_generate_uuid4() ) );
 	}
 }

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -176,34 +176,7 @@ class Bluesky {
 			$image_blob = $this->upload_image( get_post_thumbnail_id( $post->ID ), $connection['access_jwt'], $connection['did'] ); // @phpstan-ignore argument.type
 		}
 
-		// When standard.site publishing is on for this post, write the document FIRST
-		// and swap the bsky post's external link card for a record embed pointing at
-		// the document.
-		$publish_document = $this->should_publish_document_for( $post_id );
-		$document_ref     = null;
-
-		if ( $publish_document ) {
-			$document_ref = ( new Standard\Document( $this->api_client, $this->log ) )->publish(
-				$post_id,
-				null,
-				is_array( $image_blob ) ? $image_blob : null
-			);
-
-			if ( is_wp_error( $document_ref ) ) {
-				// Fall back to the regular link-card path if the document write failed.
-				$document_ref = null;
-			}
-		}
-
-		if ( is_array( $document_ref ) && ! empty( $document_ref['uri'] ) && ! empty( $document_ref['cid'] ) ) {
-			$body['record']['embed'] = [
-				'$type'  => 'app.bsky.embed.record',
-				'record' => [
-					'uri' => $document_ref['uri'],
-					'cid' => $document_ref['cid'],
-				],
-			];
-		} elseif ( ! empty( $image_blob ) ) {
+		if ( ! empty( $image_blob ) ) {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
@@ -244,13 +217,30 @@ class Bluesky {
 			]
 		);
 
+		if ( $this->should_publish_document( $post_id, $response ) ) {
+			( new Standard\Document( $this->api_client, $this->log ) )->publish(
+				$post_id,
+				[
+					'uri' => (string) $response['uri'],
+					'cid' => (string) $response['cid'],
+				],
+				is_array( $image_blob ) ? $image_blob : null
+			);
+		}
+
 		return $share;
 	}
 
 	/**
-	 * Whether this post should also produce a standard.site document record.
+	 * Whether this share should also produce a standard.site document record.
+	 *
+	 * @param array<string,mixed> $bsky_response
 	 */
-	private function should_publish_document_for( int $post_id ): bool {
+	private function should_publish_document( int $post_id, array $bsky_response ): bool {
+		if ( empty( $bsky_response['uri'] ) || empty( $bsky_response['cid'] ) ) {
+			return false;
+		}
+
 		if ( ! Utils::is_standard_site_enabled() ) {
 			return false;
 		}

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -227,18 +227,6 @@ class Bluesky {
 			]
 		);
 
-		// Back-fill bskyPostRef on the document now that we know the bsky post's URI/CID.
-		if ( ! empty( $associated_refs ) && ! empty( $response['uri'] ) && ! empty( $response['cid'] ) ) {
-			( new Standard\Document( $this->api_client, $this->log ) )->update_bsky_ref(
-				$post_id,
-				[
-					'uri' => (string) $response['uri'],
-					'cid' => (string) $response['cid'],
-				],
-				is_array( $image_blob ) ? $image_blob : null
-			);
-		}
-
 		return $share;
 	}
 

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -176,7 +176,33 @@ class Bluesky {
 			$image_blob = $this->upload_image( get_post_thumbnail_id( $post->ID ), $connection['access_jwt'], $connection['did'] ); // @phpstan-ignore argument.type
 		}
 
-		if ( ! empty( $image_blob ) ) {
+		// When standard.site publishing is on for this post, write the document FIRST
+		// and swap the bsky post's external link card for a record embed pointing at
+		// the document.
+		$publish_document = $this->should_publish_document_for( $post_id );
+		$document_ref     = null;
+
+		if ( $publish_document ) {
+			$document_ref = ( new Standard\Document( $this->api_client, $this->log ) )->publish(
+				$post_id,
+				null,
+				is_array( $image_blob ) ? $image_blob : null
+			);
+
+			if ( is_wp_error( $document_ref ) ) {
+				$document_ref = null;
+			}
+		}
+
+		if ( is_array( $document_ref ) && ! empty( $document_ref['uri'] ) && ! empty( $document_ref['cid'] ) ) {
+			$body['record']['embed'] = [
+				'$type'  => 'app.bsky.embed.record',
+				'record' => [
+					'uri' => $document_ref['uri'],
+					'cid' => $document_ref['cid'],
+				],
+			];
+		} elseif ( ! empty( $image_blob ) ) {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
@@ -217,30 +243,13 @@ class Bluesky {
 			]
 		);
 
-		if ( $this->should_publish_document( $post_id, $response ) ) {
-			( new Standard\Document( $this->api_client, $this->log ) )->publish(
-				$post_id,
-				[
-					'uri' => (string) $response['uri'],
-					'cid' => (string) $response['cid'],
-				],
-				is_array( $image_blob ) ? $image_blob : null
-			);
-		}
-
 		return $share;
 	}
 
 	/**
-	 * Whether this share should also produce a standard.site document record.
-	 *
-	 * @param array<string,mixed> $bsky_response
+	 * Whether this post should also produce a standard.site document record.
 	 */
-	private function should_publish_document( int $post_id, array $bsky_response ): bool {
-		if ( empty( $bsky_response['uri'] ) || empty( $bsky_response['cid'] ) ) {
-			return false;
-		}
-
+	private function should_publish_document_for( int $post_id ): bool {
 		if ( ! Utils::is_standard_site_enabled() ) {
 			return false;
 		}

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -176,33 +176,7 @@ class Bluesky {
 			$image_blob = $this->upload_image( get_post_thumbnail_id( $post->ID ), $connection['access_jwt'], $connection['did'] ); // @phpstan-ignore argument.type
 		}
 
-		// When standard.site publishing is on for this post, write the document FIRST
-		// and swap the bsky post's external link card for a record embed pointing at
-		// the document.
-		$publish_document = $this->should_publish_document_for( $post_id );
-		$document_ref     = null;
-
-		if ( $publish_document ) {
-			$document_ref = ( new Standard\Document( $this->api_client, $this->log ) )->publish(
-				$post_id,
-				null,
-				is_array( $image_blob ) ? $image_blob : null
-			);
-
-			if ( is_wp_error( $document_ref ) ) {
-				$document_ref = null;
-			}
-		}
-
-		if ( is_array( $document_ref ) && ! empty( $document_ref['uri'] ) && ! empty( $document_ref['cid'] ) ) {
-			$body['record']['embed'] = [
-				'$type'  => 'app.bsky.embed.record',
-				'record' => [
-					'uri' => $document_ref['uri'],
-					'cid' => $document_ref['cid'],
-				],
-			];
-		} elseif ( ! empty( $image_blob ) ) {
+		if ( ! empty( $image_blob ) ) {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
@@ -243,13 +217,30 @@ class Bluesky {
 			]
 		);
 
+		if ( $this->should_publish_document( $post_id, $response ) ) {
+			( new Standard\Document( $this->api_client, $this->log ) )->publish(
+				$post_id,
+				[
+					'uri' => (string) $response['uri'],
+					'cid' => (string) $response['cid'],
+				],
+				is_array( $image_blob ) ? $image_blob : null
+			);
+		}
+
 		return $share;
 	}
 
 	/**
-	 * Whether this post should also produce a standard.site document record.
+	 * Whether this share should also produce a standard.site document record.
+	 *
+	 * @param array<string,mixed> $bsky_response
 	 */
-	private function should_publish_document_for( int $post_id ): bool {
+	private function should_publish_document( int $post_id, array $bsky_response ): bool {
+		if ( empty( $bsky_response['uri'] ) || empty( $bsky_response['cid'] ) ) {
+			return false;
+		}
+
 		if ( ! Utils::is_standard_site_enabled() ) {
 			return false;
 		}

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -180,6 +180,16 @@ class Bluesky {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
+		// If standard.site publishing is on for this post, write the document FIRST
+		// (so we know its URI + CID) and attach strongRefs to the bsky post's
+		// external embed via associatedRefs. The bsky post still looks like a
+		// normal link card to Bluesky users; standard.site-aware clients can
+		// follow the refs to the document and publication records.
+		$associated_refs = $this->build_associated_refs( $post_id, is_array( $image_blob ) ? $image_blob : null );
+		if ( ! empty( $associated_refs ) ) {
+			$body['record']['embed']['external']['associatedRefs'] = $associated_refs;
+		}
+
 		$response = $this->api_client->create_record( $body, $connection['access_jwt'], $connection['did'] );
 
 		if ( is_wp_error( $response ) ) {
@@ -217,34 +227,59 @@ class Bluesky {
 			]
 		);
 
-		if ( $this->should_publish_document( $post_id, $response ) ) {
-			( new Standard\Document( $this->api_client, $this->log ) )->publish(
-				$post_id,
-				[
-					'uri' => (string) $response['uri'],
-					'cid' => (string) $response['cid'],
-				],
-				is_array( $image_blob ) ? $image_blob : null
-			);
-		}
-
 		return $share;
 	}
 
 	/**
-	 * Whether this share should also produce a standard.site document record.
-	 *
-	 * @param array<string,mixed> $bsky_response
+	 * Whether this post should also produce a standard.site document record.
 	 */
-	private function should_publish_document( int $post_id, array $bsky_response ): bool {
-		if ( empty( $bsky_response['uri'] ) || empty( $bsky_response['cid'] ) ) {
-			return false;
-		}
-
+	private function should_publish_document_for( int $post_id ): bool {
 		if ( ! Utils::is_standard_site_enabled() ) {
 			return false;
 		}
 
 		return (bool) get_post_meta( $post_id, 'autoblue_publish_document', true );
+	}
+
+	/**
+	 * If standard.site is enabled for this post, ensure the publication record
+	 * exists, write the document record (without bskyPostRef — we don't have
+	 * the bsky URI yet), and return strongRefs for both so the bsky post can
+	 * attach them via embed.external.associatedRefs.
+	 *
+	 * @param array<string,mixed>|null $image_blob Optional reusable cover image blob.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function build_associated_refs( int $post_id, ?array $image_blob ): array {
+		if ( ! $this->should_publish_document_for( $post_id ) ) {
+			return [];
+		}
+
+		$document    = new Standard\Document( $this->api_client, $this->log );
+		$publication = new Standard\Publication( $this->api_client, $this->log );
+
+		$doc_ref = $document->publish( $post_id, null, $image_blob );
+		if ( is_wp_error( $doc_ref ) || empty( $doc_ref['uri'] ) || empty( $doc_ref['cid'] ) ) {
+			return [];
+		}
+
+		$refs = [
+			[
+				'$type' => 'com.atproto.repo.strongRef',
+				'uri'   => $doc_ref['uri'],
+				'cid'   => $doc_ref['cid'],
+			],
+		];
+
+		$pub_ref = $publication->get_strongref();
+		if ( $pub_ref ) {
+			$refs[] = [
+				'$type' => 'com.atproto.repo.strongRef',
+				'uri'   => $pub_ref['uri'],
+				'cid'   => $pub_ref['cid'],
+			];
+		}
+
+		return $refs;
 	}
 }

--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -217,6 +217,34 @@ class Bluesky {
 			]
 		);
 
+		if ( $this->should_publish_document( $post_id, $response ) ) {
+			( new Standard\Document( $this->api_client, $this->log ) )->publish(
+				$post_id,
+				[
+					'uri' => (string) $response['uri'],
+					'cid' => (string) $response['cid'],
+				],
+				is_array( $image_blob ) ? $image_blob : null
+			);
+		}
+
 		return $share;
+	}
+
+	/**
+	 * Whether this share should also produce a standard.site document record.
+	 *
+	 * @param array<string,mixed> $bsky_response
+	 */
+	private function should_publish_document( int $post_id, array $bsky_response ): bool {
+		if ( empty( $bsky_response['uri'] ) || empty( $bsky_response['cid'] ) ) {
+			return false;
+		}
+
+		if ( ! Utils::is_standard_site_enabled() ) {
+			return false;
+		}
+
+		return (bool) get_post_meta( $post_id, 'autoblue_publish_document', true );
 	}
 }

--- a/includes/Bluesky/API.php
+++ b/includes/Bluesky/API.php
@@ -323,6 +323,39 @@ class API {
 	}
 
 	/**
+	 * Apply a batch of writes atomically via com.atproto.repo.applyWrites.
+	 *
+	 * @param array<int,array<string,mixed>> $writes
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function apply_writes( array $writes, string $access_token, string $did ) {
+		if ( empty( $writes ) || ! $access_token || ! $did ) {
+			return new \WP_Error( 'autoblue_invalid_apply_writes_args', __( 'Writes, access token, and DID are required.', 'autoblue' ) );
+		}
+
+		$pds_endpoint = $this->resolve_pds_endpoint( $did );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
+		}
+
+		return $this->send_request(
+			[
+				'endpoint' => 'com.atproto.repo.applyWrites',
+				'method'   => 'POST',
+				'headers'  => [
+					'Authorization' => 'Bearer ' . $access_token,
+				],
+				'body'     => [
+					'repo'   => $did,
+					'writes' => $writes,
+				],
+				'base_url' => $pds_endpoint,
+			]
+		);
+	}
+
+	/**
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function upload_blob( string $blob, string $mime_type, string $access_token, string $did ) {

--- a/includes/Bluesky/API.php
+++ b/includes/Bluesky/API.php
@@ -254,6 +254,45 @@ class API {
 	}
 
 	/**
+	 * List records in a collection via com.atproto.repo.listRecords.
+	 *
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function list_records( string $repo, string $collection, string $access_token, ?string $cursor = null, int $limit = 100 ) {
+		if ( ! $repo || ! $collection || ! $access_token ) {
+			return new \WP_Error( 'autoblue_invalid_list_records_args', __( 'Repo, collection, and access token are required.', 'autoblue' ) );
+		}
+
+		$pds_endpoint = $this->resolve_pds_endpoint( $repo );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
+		}
+
+		$body = [
+			'repo'       => $repo,
+			'collection' => $collection,
+			'limit'      => $limit,
+		];
+
+		if ( $cursor ) {
+			$body['cursor'] = $cursor;
+		}
+
+		return $this->send_request(
+			[
+				'endpoint' => 'com.atproto.repo.listRecords',
+				'method'   => 'GET',
+				'headers'  => [
+					'Authorization' => 'Bearer ' . $access_token,
+				],
+				'body'     => $body,
+				'base_url' => $pds_endpoint,
+			]
+		);
+	}
+
+	/**
 	 * Create-or-update a record at a known rkey via com.atproto.repo.putRecord.
 	 *
 	 * @param array<string, mixed> $record Must include repo, collection, rkey, record.

--- a/includes/Bluesky/API.php
+++ b/includes/Bluesky/API.php
@@ -254,6 +254,36 @@ class API {
 	}
 
 	/**
+	 * Create-or-update a record at a known rkey via com.atproto.repo.putRecord.
+	 *
+	 * @param array<string, mixed> $record Must include repo, collection, rkey, record.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function put_record( array $record, string $access_token, string $did ) {
+		if ( ! $record || ! $access_token ) {
+			return new \WP_Error( 'autoblue_invalid_record_or_access_token', __( 'Invalid record or access token.', 'autoblue' ) );
+		}
+
+		$pds_endpoint = $this->resolve_pds_endpoint( $did );
+
+		if ( is_wp_error( $pds_endpoint ) ) {
+			return $pds_endpoint;
+		}
+
+		return $this->send_request(
+			[
+				'endpoint' => 'com.atproto.repo.putRecord',
+				'method'   => 'POST',
+				'headers'  => [
+					'Authorization' => 'Bearer ' . $access_token,
+				],
+				'body'     => $record,
+				'base_url' => $pds_endpoint,
+			]
+		);
+	}
+
+	/**
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public function upload_blob( string $blob, string $mime_type, string $access_token, string $did ) {

--- a/includes/ConnectionsManager.php
+++ b/includes/ConnectionsManager.php
@@ -71,6 +71,14 @@ class ConnectionsManager {
 			$this->log->success( __( 'Connection added.', 'autoblue' ), [ 'did' => $did ] );
 		}
 
+		/**
+		 * Fires after a Bluesky connection is added or refreshed via reconnect.
+		 *
+		 * @param array<string,mixed> $new_connection The freshly stored connection.
+		 * @param bool                $is_reconnect   Whether this was a reconnect of an existing DID.
+		 */
+		do_action( 'autoblue/connection_added', $new_connection, $is_reconnect );
+
 		return $new_connection;
 	}
 

--- a/includes/Endpoints/StandardRecordsController.php
+++ b/includes/Endpoints/StandardRecordsController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Autoblue\Endpoints;
+
+use Autoblue\Bluesky\API;
+use Autoblue\ConnectionsManager;
+use Autoblue\Standard\Publication;
+use Autoblue\Utils;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Surfaces the standard.site records currently on the connected PDS so the
+ * admin "Records" tab can render them.
+ */
+class StandardRecordsController extends WP_REST_Controller {
+	public function __construct() {
+		$this->namespace = 'autoblue/v1';
+		$this->rest_base = 'standard/records';
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_records' ],
+					'permission_callback' => [ $this, 'permissions_check' ],
+					'args'                => [
+						'cursor' => [
+							'type'    => 'string',
+							'default' => '',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	public function permissions_check(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * GET /autoblue/v1/standard/records?cursor=...
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_records( \WP_REST_Request $request ) {
+		if ( ! Utils::is_standard_site_enabled() ) {
+			return new \WP_Error(
+				'autoblue_standard_site_disabled',
+				__( 'standard.site publishing is not enabled.', 'autoblue' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$connections_manager = new ConnectionsManager();
+		$connections         = $connections_manager->get_all_connections();
+		if ( empty( $connections ) ) {
+			return new \WP_Error( 'autoblue_no_connection', __( 'No Bluesky connection found.', 'autoblue' ), [ 'status' => 400 ] );
+		}
+
+		$connection = $connections_manager->refresh_tokens( $connections[0]['did'] );
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		$api    = new API();
+		$cursor = (string) $request->get_param( 'cursor' );
+
+		$publication = null;
+		if ( '' === $cursor ) {
+			$pub_uri = ( new Publication() )->get_uri();
+			if ( $pub_uri ) {
+				$pub_response = $api->list_records(
+					$connection['did'],
+					'site.standard.publication',
+					$connection['access_jwt']
+				);
+				if ( ! is_wp_error( $pub_response ) && ! empty( $pub_response['records'] ) ) {
+					foreach ( $pub_response['records'] as $record ) {
+						if ( isset( $record['uri'] ) && $record['uri'] === $pub_uri ) {
+							$publication = $record;
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		$docs_response = $api->list_records(
+			$connection['did'],
+			'site.standard.document',
+			$connection['access_jwt'],
+			$cursor ?: null
+		);
+
+		if ( is_wp_error( $docs_response ) ) {
+			return $docs_response;
+		}
+
+		return rest_ensure_response(
+			[
+				'publication' => $publication,
+				'documents'   => $docs_response['records'] ?? [],
+				'cursor'      => $docs_response['cursor'] ?? null,
+			]
+		);
+	}
+}

--- a/includes/Meta.php
+++ b/includes/Meta.php
@@ -80,6 +80,18 @@ class Meta {
 					'sanitize_callback' => 'esc_url_raw',
 				]
 			);
+
+			register_post_meta(
+				$post_type,
+				'autoblue_publish_document',
+				[
+					'type'         => 'boolean',
+					'description'  => __( 'Whether the post should be published as a standard.site document.', 'autoblue' ),
+					'single'       => true,
+					'show_in_rest' => true,
+					'default'      => (bool) get_option( 'autoblue_publish_documents_enabled', false ),
+				]
+			);
 		}
 	}
 }

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -11,6 +11,8 @@ class Setup {
 		( new PostHandler() )->register_hooks();
 		( new ConnectionsManager() )->register_hooks();
 		( new Logging\Setup() )->register_hooks();
+		( new Standard\Publication() )->register_hooks();
+		( new Standard\Verification() )->register_hooks();
 		( new CLI\Commands() )->register_commands();
 
 		add_action( 'rest_api_init', [ new Endpoints\LogsController(), 'register_routes' ] );

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -19,6 +19,7 @@ class Setup {
 		add_action( 'rest_api_init', [ new Endpoints\SearchController(), 'register_routes' ] );
 		add_action( 'rest_api_init', [ new Endpoints\AccountController(), 'register_routes' ] );
 		add_action( 'rest_api_init', [ new Endpoints\ConnectionsController(), 'register_routes' ] );
+		add_action( 'rest_api_init', [ new Endpoints\StandardRecordsController(), 'register_routes' ] );
 	}
 
 	public static function activate(): void {

--- a/includes/Standard/Document.php
+++ b/includes/Standard/Document.php
@@ -30,18 +30,22 @@ class Document {
 	/**
 	 * Publish a post as a standard.site document.
 	 *
-	 * @param int                              $post_id
-	 * @param array{uri:string,cid:string}     $bsky_post_ref
-	 * @param array<string,mixed>|null         $cover_blob_ref Optional reusable blob ref from the bsky post upload.
+	 * @param int                                   $post_id
+	 * @param array{uri:string,cid:string}|null     $bsky_post_ref
+	 *        Optional Bluesky strongRef. Pass null to publish a document without a
+	 *        back-reference (e.g. when writing the document BEFORE the bsky post so
+	 *        the bsky post can embed it via app.bsky.embed.record).
+	 * @param array<string,mixed>|null              $cover_blob_ref
+	 *        Optional reusable blob ref from the bsky post upload.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function publish( int $post_id, array $bsky_post_ref, ?array $cover_blob_ref = null ) {
+	public function publish( int $post_id, ?array $bsky_post_ref, ?array $cover_blob_ref = null ) {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
 		}
 
-		if ( empty( $bsky_post_ref['uri'] ) || empty( $bsky_post_ref['cid'] ) ) {
+		if ( null !== $bsky_post_ref && ( empty( $bsky_post_ref['uri'] ) || empty( $bsky_post_ref['cid'] ) ) ) {
 			return new \WP_Error( 'autoblue_document_invalid_bsky_ref', __( 'A Bluesky post URI and CID are required.', 'autoblue' ) );
 		}
 
@@ -112,23 +116,26 @@ class Document {
 	}
 
 	/**
-	 * @param \WP_Post                          $post
-	 * @param string                            $publication_uri
-	 * @param array{uri:string,cid:string}      $bsky_post_ref
-	 * @param array<string,mixed>|null          $cover_blob_ref
+	 * @param \WP_Post                              $post
+	 * @param string                                $publication_uri
+	 * @param array{uri:string,cid:string}|null     $bsky_post_ref
+	 * @param array<string,mixed>|null              $cover_blob_ref
 	 * @return array<string,mixed>
 	 */
-	public function build_record( \WP_Post $post, string $publication_uri, array $bsky_post_ref, ?array $cover_blob_ref ): array {
+	public function build_record( \WP_Post $post, string $publication_uri, ?array $bsky_post_ref, ?array $cover_blob_ref ): array {
 		$record = [
 			'$type'       => self::COLLECTION,
 			'site'        => $publication_uri,
 			'title'       => html_entity_decode( get_the_title( $post ), ENT_QUOTES ),
 			'publishedAt' => gmdate( 'c', strtotime( $post->post_date_gmt ) ?: time() ),
-			'bskyPostRef' => [
+		];
+
+		if ( $bsky_post_ref ) {
+			$record['bskyPostRef'] = [
 				'uri' => $bsky_post_ref['uri'],
 				'cid' => $bsky_post_ref['cid'],
-			],
-		];
+			];
+		}
 
 		$path = wp_parse_url( get_permalink( $post ), PHP_URL_PATH );
 		if ( is_string( $path ) && '' !== $path ) {

--- a/includes/Standard/Document.php
+++ b/includes/Standard/Document.php
@@ -116,6 +116,75 @@ class Document {
 	}
 
 	/**
+	 * Back-fill bskyPostRef onto an already-published document.
+	 *
+	 * Called after the Bluesky post lands so we can point the document at
+	 * its corresponding bsky post (useful for comment threading and
+	 * reverse navigation in standard.site-aware readers).
+	 *
+	 * @param array{uri:string,cid:string} $bsky_post_ref
+	 * @param array<string,mixed>|null     $cover_blob_ref Reused so coverImage stays intact.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function update_bsky_ref( int $post_id, array $bsky_post_ref, ?array $cover_blob_ref = null ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
+		}
+
+		$stored = get_post_meta( $post_id, self::META_KEY, true );
+		if ( ! is_array( $stored ) || empty( $stored['rkey'] ) ) {
+			return new \WP_Error( 'autoblue_document_not_published', __( 'Document not yet published.', 'autoblue' ) );
+		}
+
+		$publication_uri = $this->publication->get_uri();
+		if ( ! $publication_uri ) {
+			return new \WP_Error( 'autoblue_publication_missing', __( 'Publication unavailable.', 'autoblue' ) );
+		}
+
+		$connection = $this->get_active_connection();
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		$record = $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref );
+
+		$response = $this->api_client->put_record(
+			[
+				'repo'       => $connection['did'],
+				'collection' => self::COLLECTION,
+				'rkey'       => $stored['rkey'],
+				'record'     => $record,
+			],
+			$connection['access_jwt'],
+			$connection['did']
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log->error(
+				__( 'Failed to back-fill bskyPostRef on standard.site document for post `{post_title}` with ID `{post_id}`: {message}', 'autoblue' ),
+				[
+					'post_id'    => $post_id,
+					'post_title' => $post->post_title,
+					'message'    => $response->get_error_message(),
+				]
+			);
+			return $response;
+		}
+
+		update_post_meta(
+			$post_id,
+			self::META_KEY,
+			array_merge(
+				$stored,
+				[ 'cid' => (string) ( $response['cid'] ?? $stored['cid'] ) ]
+			)
+		);
+
+		return $response;
+	}
+
+	/**
 	 * @param \WP_Post                              $post
 	 * @param string                                $publication_uri
 	 * @param array{uri:string,cid:string}|null     $bsky_post_ref

--- a/includes/Standard/Document.php
+++ b/includes/Standard/Document.php
@@ -68,11 +68,13 @@ class Document {
 		}
 
 		$record = $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref );
+		$rkey   = $this->get_rkey( $post_id );
 
 		$response = $this->api_client->create_record(
 			[
 				'repo'       => $connection['did'],
 				'collection' => self::COLLECTION,
+				'rkey'       => $rkey,
 				'record'     => $record,
 			],
 			$connection['access_jwt'],
@@ -95,13 +97,7 @@ class Document {
 			return new \WP_Error( 'autoblue_invalid_document_response', __( 'Document record was created but no URI was returned.', 'autoblue' ) );
 		}
 
-		$stored = [
-			'uri'  => (string) $response['uri'],
-			'cid'  => (string) ( $response['cid'] ?? '' ),
-			'rkey' => $this->extract_rkey( (string) $response['uri'] ),
-		];
-
-		update_post_meta( $post_id, self::META_KEY, $stored );
+		$stored = $this->store_meta( $post_id, $response, $rkey );
 
 		$this->log->success(
 			__( 'Published standard.site document for post `{post_title}` with ID `{post_id}` at {uri}.', 'autoblue' ),
@@ -116,6 +112,67 @@ class Document {
 	}
 
 	/**
+	 * Prepare the document record for an external batch write.
+	 *
+	 * @param array{uri:string,cid:string}|null $bsky_post_ref
+	 * @param array<string,mixed>|null          $cover_blob_ref
+	 * @return array{rkey:string,record:array<string,mixed>}|\WP_Error
+	 */
+	public function prepare_record( int $post_id, string $publication_uri, ?array $bsky_post_ref, ?array $cover_blob_ref = null ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
+		}
+
+		if ( null !== $bsky_post_ref && ( empty( $bsky_post_ref['uri'] ) || empty( $bsky_post_ref['cid'] ) ) ) {
+			return new \WP_Error( 'autoblue_document_invalid_bsky_ref', __( 'A Bluesky post URI and CID are required.', 'autoblue' ) );
+		}
+
+		return [
+			'rkey'   => $this->get_rkey( $post_id ),
+			'record' => $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref ),
+		];
+	}
+
+	/**
+	 * Persist document metadata from a PDS write response.
+	 *
+	 * @param array<string,mixed> $response
+	 * @return array{uri:string,cid:string,rkey:string}
+	 */
+	public function store_meta( int $post_id, array $response, ?string $rkey = null ): array {
+		$uri    = (string) ( $response['uri'] ?? '' );
+		$stored = [
+			'uri'  => $uri,
+			'cid'  => (string) ( $response['cid'] ?? '' ),
+			'rkey' => $rkey ?: $this->extract_rkey( $uri ),
+		];
+
+		update_post_meta( $post_id, self::META_KEY, $stored );
+
+		return $stored;
+	}
+
+	public function get_rkey( int $post_id ): string {
+		$stored = get_post_meta( $post_id, self::META_KEY, true );
+		if ( is_array( $stored ) && ! empty( $stored['rkey'] ) ) {
+			return (string) $stored['rkey'];
+		}
+
+		$rkey = 'ab' . strtolower( str_replace( '-', '', wp_generate_uuid4() ) );
+		update_post_meta(
+			$post_id,
+			self::META_KEY,
+			array_merge(
+				is_array( $stored ) ? $stored : [],
+				[ 'rkey' => $rkey ]
+			)
+		);
+
+		return $rkey;
+	}
+
+	/**
 	 * Back-fill bskyPostRef onto an already-published document.
 	 *
 	 * Called after the Bluesky post lands so we can point the document at
@@ -124,9 +181,10 @@ class Document {
 	 *
 	 * @param array{uri:string,cid:string} $bsky_post_ref
 	 * @param array<string,mixed>|null     $cover_blob_ref Reused so coverImage stays intact.
+	 * @param array<string,mixed>|null     $connection Already-refreshed connection.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function update_bsky_ref( int $post_id, array $bsky_post_ref, ?array $cover_blob_ref = null ) {
+	public function update_bsky_ref( int $post_id, array $bsky_post_ref, ?array $cover_blob_ref = null, ?array $connection = null ) {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
@@ -142,9 +200,11 @@ class Document {
 			return new \WP_Error( 'autoblue_publication_missing', __( 'Publication unavailable.', 'autoblue' ) );
 		}
 
-		$connection = $this->get_active_connection();
-		if ( is_wp_error( $connection ) ) {
-			return $connection;
+		if ( null === $connection ) {
+			$connection = $this->get_active_connection();
+			if ( is_wp_error( $connection ) ) {
+				return $connection;
+			}
 		}
 
 		$record = $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref );
@@ -256,16 +316,20 @@ class Document {
 	private function build_tags( \WP_Post $post ): array {
 		$tags  = [];
 		$terms = wp_get_post_tags( $post->ID );
-		foreach ( $terms as $term ) {
-			$tags[] = $term->name;
+		if ( ! is_wp_error( $terms ) ) {
+			foreach ( $terms as $term ) {
+				$tags[] = $term->name;
+			}
 		}
 
 		$cats = wp_get_post_categories( $post->ID, [ 'fields' => 'all' ] );
-		foreach ( $cats as $cat ) {
-			if ( 'uncategorized' === $cat->slug ) {
-				continue;
+		if ( ! is_wp_error( $cats ) ) {
+			foreach ( $cats as $cat ) {
+				if ( 'uncategorized' === $cat->slug ) {
+					continue;
+				}
+				$tags[] = $cat->name;
 			}
-			$tags[] = $cat->name;
 		}
 
 		$tags = array_values( array_unique( array_filter( array_map( 'strval', $tags ) ) ) );

--- a/includes/Standard/Document.php
+++ b/includes/Standard/Document.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Autoblue\Standard;
+
+use Autoblue\Bluesky\API;
+use Autoblue\Logging\Log;
+
+/**
+ * Publishes WordPress posts as `site.standard.document` records on the PDS.
+ */
+class Document {
+	private const META_KEY   = 'autoblue_document';
+	private const COLLECTION = 'site.standard.document';
+
+	/** @var API */
+	private $api_client;
+
+	/** @var Log */
+	private $log;
+
+	/** @var Publication */
+	private $publication;
+
+	public function __construct( ?API $api_client = null, ?Log $log = null, ?Publication $publication = null ) {
+		$this->api_client  = $api_client ?: new API();
+		$this->log         = $log ?: new Log();
+		$this->publication = $publication ?: new Publication( $this->api_client, $this->log );
+	}
+
+	/**
+	 * Publish a post as a standard.site document.
+	 *
+	 * @param int                              $post_id
+	 * @param array{uri:string,cid:string}     $bsky_post_ref
+	 * @param array<string,mixed>|null         $cover_blob_ref Optional reusable blob ref from the bsky post upload.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function publish( int $post_id, array $bsky_post_ref, ?array $cover_blob_ref = null ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
+		}
+
+		if ( empty( $bsky_post_ref['uri'] ) || empty( $bsky_post_ref['cid'] ) ) {
+			return new \WP_Error( 'autoblue_document_invalid_bsky_ref', __( 'A Bluesky post URI and CID are required.', 'autoblue' ) );
+		}
+
+		$publication_uri = $this->publication->ensure_exists();
+		if ( is_wp_error( $publication_uri ) ) {
+			$this->log->error(
+				__( 'Skipping standard.site document for post `{post_title}` with ID `{post_id}`: publication unavailable.', 'autoblue' ),
+				[
+					'post_id'    => $post_id,
+					'post_title' => $post->post_title,
+					'message'    => $publication_uri->get_error_message(),
+				]
+			);
+			return $publication_uri;
+		}
+
+		$connection = $this->get_active_connection();
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		$record = $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref );
+
+		$response = $this->api_client->create_record(
+			[
+				'repo'       => $connection['did'],
+				'collection' => self::COLLECTION,
+				'record'     => $record,
+			],
+			$connection['access_jwt'],
+			$connection['did']
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log->error(
+				__( 'Failed to publish standard.site document for post `{post_title}` with ID `{post_id}`: {message}', 'autoblue' ),
+				[
+					'post_id'    => $post_id,
+					'post_title' => $post->post_title,
+					'message'    => $response->get_error_message(),
+				]
+			);
+			return $response;
+		}
+
+		if ( empty( $response['uri'] ) ) {
+			return new \WP_Error( 'autoblue_invalid_document_response', __( 'Document record was created but no URI was returned.', 'autoblue' ) );
+		}
+
+		$stored = [
+			'uri'  => (string) $response['uri'],
+			'cid'  => (string) ( $response['cid'] ?? '' ),
+			'rkey' => $this->extract_rkey( (string) $response['uri'] ),
+		];
+
+		update_post_meta( $post_id, self::META_KEY, $stored );
+
+		$this->log->success(
+			__( 'Published standard.site document for post `{post_title}` with ID `{post_id}` at {uri}.', 'autoblue' ),
+			[
+				'post_id'    => $post_id,
+				'post_title' => $post->post_title,
+				'uri'        => $stored['uri'],
+			]
+		);
+
+		return $stored;
+	}
+
+	/**
+	 * @param \WP_Post                          $post
+	 * @param string                            $publication_uri
+	 * @param array{uri:string,cid:string}      $bsky_post_ref
+	 * @param array<string,mixed>|null          $cover_blob_ref
+	 * @return array<string,mixed>
+	 */
+	public function build_record( \WP_Post $post, string $publication_uri, array $bsky_post_ref, ?array $cover_blob_ref ): array {
+		$record = [
+			'$type'       => self::COLLECTION,
+			'site'        => $publication_uri,
+			'title'       => html_entity_decode( get_the_title( $post ), ENT_QUOTES ),
+			'publishedAt' => gmdate( 'c', strtotime( $post->post_date_gmt ) ?: time() ),
+			'bskyPostRef' => [
+				'uri' => $bsky_post_ref['uri'],
+				'cid' => $bsky_post_ref['cid'],
+			],
+		];
+
+		$path = wp_parse_url( get_permalink( $post ), PHP_URL_PATH );
+		if ( is_string( $path ) && '' !== $path ) {
+			$record['path'] = $path;
+		}
+
+		$description = $this->build_description( $post );
+		if ( '' !== $description ) {
+			$record['description'] = $description;
+		}
+
+		$text = $this->render_plain_text( $post );
+		if ( '' !== $text ) {
+			$record['textContent'] = $text;
+		}
+
+		$tags = $this->build_tags( $post );
+		if ( ! empty( $tags ) ) {
+			$record['tags'] = $tags;
+		}
+
+		if ( $cover_blob_ref ) {
+			$record['coverImage'] = $cover_blob_ref;
+		}
+
+		if ( $post->post_modified_gmt && $post->post_modified_gmt !== $post->post_date_gmt ) {
+			$record['updatedAt'] = gmdate( 'c', strtotime( $post->post_modified_gmt ) ?: time() );
+		}
+
+		return $record;
+	}
+
+	private function build_description( \WP_Post $post ): string {
+		$excerpt = get_the_excerpt( $post );
+		return trim( html_entity_decode( wp_strip_all_tags( (string) $excerpt ), ENT_QUOTES ) );
+	}
+
+	private function render_plain_text( \WP_Post $post ): string {
+		$content = apply_filters( 'the_content', $post->post_content );
+		$content = wp_strip_all_tags( (string) $content );
+		$content = html_entity_decode( $content, ENT_QUOTES );
+		$content = preg_replace( '/\s+/u', ' ', $content );
+		return trim( (string) $content );
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private function build_tags( \WP_Post $post ): array {
+		$tags  = [];
+		$terms = wp_get_post_tags( $post->ID );
+		foreach ( $terms as $term ) {
+			$tags[] = $term->name;
+		}
+
+		$cats = wp_get_post_categories( $post->ID, [ 'fields' => 'all' ] );
+		foreach ( $cats as $cat ) {
+			if ( 'uncategorized' === $cat->slug ) {
+				continue;
+			}
+			$tags[] = $cat->name;
+		}
+
+		$tags = array_values( array_unique( array_filter( array_map( 'strval', $tags ) ) ) );
+		return array_slice( $tags, 0, 8 );
+	}
+
+	/**
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function get_active_connection() {
+		$connections_manager = new \Autoblue\ConnectionsManager();
+		$connections         = $connections_manager->get_all_connections();
+		if ( empty( $connections ) ) {
+			return new \WP_Error( 'autoblue_no_connection', __( 'No Bluesky connection found.', 'autoblue' ) );
+		}
+
+		$connection = $connections_manager->refresh_tokens( $connections[0]['did'] );
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		return $connection;
+	}
+
+	private function extract_rkey( string $uri ): string {
+		$parts = explode( '/', $uri );
+		return (string) end( $parts );
+	}
+}

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -153,7 +153,59 @@ class Publication {
 			$record['icon'] = $icon_blob;
 		}
 
+		$basic_theme = $this->build_basic_theme( $overrides );
+		if ( $basic_theme ) {
+			$record['basicTheme'] = $basic_theme;
+		}
+
 		return $record;
+	}
+
+	/**
+	 * Build the inline site.standard.theme.basic value from hex overrides.
+	 *
+	 * @param array<string,mixed> $overrides
+	 * @return array<string,array<string,int>>|null
+	 */
+	private function build_basic_theme( array $overrides ): ?array {
+		$mapping = [
+			'background'      => 'theme_background',
+			'foreground'      => 'theme_foreground',
+			'accent'          => 'theme_accent',
+			'accentForeground' => 'theme_accent_foreground',
+		];
+
+		$theme = [ '$type' => 'site.standard.theme.basic' ];
+		foreach ( $mapping as $field => $key ) {
+			$rgb = $this->hex_to_rgb( $overrides[ $key ] ?? null );
+			if ( $rgb ) {
+				$theme[ $field ] = $rgb;
+			}
+		}
+
+		// Only return the theme if at least one colour was set.
+		return count( $theme ) > 1 ? $theme : null;
+	}
+
+	/**
+	 * @return array{r:int,g:int,b:int}|null
+	 */
+	private function hex_to_rgb( $hex ): ?array {
+		if ( ! is_string( $hex ) ) {
+			return null;
+		}
+		$hex = ltrim( trim( $hex ), '#' );
+		if ( 3 === strlen( $hex ) ) {
+			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+		}
+		if ( ! preg_match( '/^[0-9a-fA-F]{6}$/', $hex ) ) {
+			return null;
+		}
+		return [
+			'r' => hexdec( substr( $hex, 0, 2 ) ),
+			'g' => hexdec( substr( $hex, 2, 2 ) ),
+			'b' => hexdec( substr( $hex, 4, 2 ) ),
+		];
 	}
 
 	/**

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -32,6 +32,69 @@ class Publication {
 		add_action( 'update_option_blogdescription', [ $this, 'sync' ] );
 		add_action( 'update_option_site_icon', [ $this, 'sync' ] );
 		add_action( 'update_option_' . self::OVERRIDES_KEY, [ $this, 'sync' ] );
+		add_action( 'autoblue/connection_added', [ $this, 'maybe_adopt_existing' ], 10, 2 );
+	}
+
+	/**
+	 * On a fresh Bluesky connection, search the user's PDS for a publication
+	 * record whose `url` matches our home_url() and adopt it instead of writing
+	 * a duplicate on the next publish. No-op on reconnects of the same DID.
+	 *
+	 * @param array<string,mixed> $connection
+	 */
+	public function maybe_adopt_existing( array $connection, bool $is_reconnect = false ): void {
+		if ( empty( $connection['did'] ) || empty( $connection['access_jwt'] ) ) {
+			return;
+		}
+
+		$stored = get_option( self::OPTION_KEY, [] );
+		if ( ! empty( $stored['uri'] ) && ! empty( $stored['did'] ) && $stored['did'] === $connection['did'] ) {
+			// Already linked to this DID's publication.
+			return;
+		}
+
+		$response = $this->api_client->list_records(
+			$connection['did'],
+			self::COLLECTION,
+			$connection['access_jwt']
+		);
+
+		if ( is_wp_error( $response ) || empty( $response['records'] ) ) {
+			return;
+		}
+
+		$home = untrailingslashit( home_url( '/' ) );
+		foreach ( $response['records'] as $record ) {
+			$value = $record['value'] ?? [];
+			$url   = isset( $value['url'] ) ? untrailingslashit( (string) $value['url'] ) : '';
+			if ( $url !== $home ) {
+				continue;
+			}
+
+			$uri  = isset( $record['uri'] ) ? (string) $record['uri'] : '';
+			$cid  = isset( $record['cid'] ) ? (string) $record['cid'] : '';
+			$rkey = $this->extract_rkey( $uri );
+			if ( ! $uri || ! $rkey ) {
+				continue;
+			}
+
+			update_option(
+				self::OPTION_KEY,
+				[
+					'did'         => $connection['did'],
+					'uri'         => $uri,
+					'cid'         => $cid,
+					'rkey'        => $rkey,
+					'fingerprint' => $this->fingerprint( $value ),
+				]
+			);
+
+			$this->log->info(
+				__( 'Adopted existing standard.site publication record at {uri}.', 'autoblue' ),
+				[ 'uri' => $uri ]
+			);
+			return;
+		}
 	}
 
 	/**

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -254,7 +254,7 @@ class Publication {
 			'accentForeground' => 'theme_accent_foreground',
 		];
 
-		$theme = [ '$type' => 'site.standard.theme.basic' ];
+		$theme = [];
 		foreach ( $mapping as $field => $key ) {
 			$rgb = $this->hex_to_rgb( $overrides[ $key ] ?? null );
 			if ( $rgb ) {
@@ -263,11 +263,11 @@ class Publication {
 		}
 
 		// Only return the theme if at least one colour was set.
-		return count( $theme ) > 1 ? $theme : null;
+		return ! empty( $theme ) ? $theme : null;
 	}
 
 	/**
-	 * @return array{r:int,g:int,b:int}|null
+	 * @return array{'$type':string,r:int,g:int,b:int}|null
 	 */
 	private function hex_to_rgb( $hex ): ?array {
 		if ( ! is_string( $hex ) ) {
@@ -281,9 +281,10 @@ class Publication {
 			return null;
 		}
 		return [
-			'r' => hexdec( substr( $hex, 0, 2 ) ),
-			'g' => hexdec( substr( $hex, 2, 2 ) ),
-			'b' => hexdec( substr( $hex, 4, 2 ) ),
+			'$type' => 'site.standard.theme.color#rgb',
+			'r'     => hexdec( substr( $hex, 0, 2 ) ),
+			'g'     => hexdec( substr( $hex, 2, 2 ) ),
+			'b'     => hexdec( substr( $hex, 4, 2 ) ),
 		];
 	}
 

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -43,6 +43,8 @@ class Publication {
 	 * @param array<string,mixed> $connection
 	 */
 	public function maybe_adopt_existing( array $connection, bool $is_reconnect = false ): void {
+		unset( $is_reconnect );
+
 		if ( empty( $connection['did'] ) || empty( $connection['access_jwt'] ) ) {
 			return;
 		}
@@ -108,6 +110,17 @@ class Publication {
 			return $connection;
 		}
 
+		return $this->ensure_exists_for_connection( $connection );
+	}
+
+	/**
+	 * Return the publication AT-URI for an already-refreshed connection,
+	 * creating the record if missing.
+	 *
+	 * @param array<string,mixed> $connection
+	 * @return string|\WP_Error
+	 */
+	public function ensure_exists_for_connection( array $connection ) {
 		$stored = get_option( self::OPTION_KEY, [] );
 		if ( ! empty( $stored['uri'] ) && ! empty( $stored['did'] ) && $stored['did'] === $connection['did'] ) {
 			return $stored['uri'];
@@ -244,13 +257,13 @@ class Publication {
 	 * Build the inline site.standard.theme.basic value from hex overrides.
 	 *
 	 * @param array<string,mixed> $overrides
-	 * @return array<string,array<string,int>>|null
+	 * @return array<string,mixed>|null
 	 */
 	private function build_basic_theme( array $overrides ): ?array {
 		$mapping = [
-			'background'      => 'theme_background',
-			'foreground'      => 'theme_foreground',
-			'accent'          => 'theme_accent',
+			'background'       => 'theme_background',
+			'foreground'       => 'theme_foreground',
+			'accent'           => 'theme_accent',
 			'accentForeground' => 'theme_accent_foreground',
 		];
 
@@ -267,6 +280,7 @@ class Publication {
 	}
 
 	/**
+	 * @param mixed $hex
 	 * @return array{'$type':string,r:int,g:int,b:int}|null
 	 */
 	private function hex_to_rgb( $hex ): ?array {
@@ -282,9 +296,9 @@ class Publication {
 		}
 		return [
 			'$type' => 'site.standard.theme.color#rgb',
-			'r'     => hexdec( substr( $hex, 0, 2 ) ),
-			'g'     => hexdec( substr( $hex, 2, 2 ) ),
-			'b'     => hexdec( substr( $hex, 4, 2 ) ),
+			'r'     => (int) hexdec( substr( $hex, 0, 2 ) ),
+			'g'     => (int) hexdec( substr( $hex, 2, 2 ) ),
+			'b'     => (int) hexdec( substr( $hex, 4, 2 ) ),
 		];
 	}
 
@@ -356,6 +370,9 @@ class Publication {
 		return $connection;
 	}
 
+	/**
+	 * @param mixed $override
+	 */
 	private function resolve_string( $override, string $fallback ): string {
 		if ( is_string( $override ) && '' !== trim( $override ) ) {
 			return $override;
@@ -364,6 +381,7 @@ class Publication {
 	}
 
 	/**
+	 * @param mixed               $override_id
 	 * @param array<string,mixed> $connection
 	 * @return array<string,mixed>|null
 	 */

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace Autoblue\Standard;
+
+use Autoblue\Bluesky\API;
+use Autoblue\ConnectionsManager;
+use Autoblue\ImageCompressor;
+use Autoblue\Logging\Log;
+use Autoblue\Utils;
+
+/**
+ * Manages the site's `site.standard.publication` record on the connected PDS.
+ */
+class Publication {
+	private const OPTION_KEY    = 'autoblue_publication_record';
+	private const OVERRIDES_KEY = 'autoblue_publication_overrides';
+	private const COLLECTION    = 'site.standard.publication';
+
+	/** @var API */
+	private $api_client;
+
+	/** @var Log */
+	private $log;
+
+	public function __construct( ?API $api_client = null, ?Log $log = null ) {
+		$this->api_client = $api_client ?: new API();
+		$this->log        = $log ?: new Log();
+	}
+
+	public function register_hooks(): void {
+		add_action( 'update_option_blogname', [ $this, 'sync' ] );
+		add_action( 'update_option_blogdescription', [ $this, 'sync' ] );
+		add_action( 'update_option_site_icon', [ $this, 'sync' ] );
+		add_action( 'update_option_' . self::OVERRIDES_KEY, [ $this, 'sync' ] );
+	}
+
+	/**
+	 * Return the publication's AT-URI, creating the record if missing.
+	 *
+	 * @return string|\WP_Error
+	 */
+	public function ensure_exists() {
+		$connection = $this->get_active_connection();
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		$stored = get_option( self::OPTION_KEY, [] );
+		if ( ! empty( $stored['uri'] ) && ! empty( $stored['did'] ) && $stored['did'] === $connection['did'] ) {
+			return $stored['uri'];
+		}
+
+		return $this->create( $connection );
+	}
+
+	/**
+	 * Get the cached publication AT-URI without making network calls.
+	 */
+	public function get_uri(): ?string {
+		$stored = get_option( self::OPTION_KEY, [] );
+		return ! empty( $stored['uri'] ) ? (string) $stored['uri'] : null;
+	}
+
+	/**
+	 * Reactively update the publication record when WP settings or overrides change.
+	 */
+	public function sync(): void {
+		if ( ! Utils::is_standard_site_enabled() ) {
+			return;
+		}
+
+		$stored = get_option( self::OPTION_KEY, [] );
+		if ( empty( $stored['uri'] ) || empty( $stored['rkey'] ) || empty( $stored['did'] ) ) {
+			return;
+		}
+
+		$connection = $this->get_active_connection();
+		if ( is_wp_error( $connection ) || $connection['did'] !== $stored['did'] ) {
+			return;
+		}
+
+		$record      = $this->build_record( $connection );
+		$fingerprint = $this->fingerprint( $record );
+		if ( ! empty( $stored['fingerprint'] ) && $stored['fingerprint'] === $fingerprint ) {
+			return;
+		}
+
+		$response = $this->api_client->put_record(
+			[
+				'repo'       => $connection['did'],
+				'collection' => self::COLLECTION,
+				'rkey'       => $stored['rkey'],
+				'record'     => $record,
+			],
+			$connection['access_jwt'],
+			$connection['did']
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log->error(
+				__( 'Failed to update standard.site publication record: {message}', 'autoblue' ),
+				[ 'message' => $response->get_error_message() ]
+			);
+			return;
+		}
+
+		update_option(
+			self::OPTION_KEY,
+			[
+				'did'         => $connection['did'],
+				'uri'         => (string) ( $response['uri'] ?? $stored['uri'] ),
+				'cid'         => (string) ( $response['cid'] ?? '' ),
+				'rkey'        => $stored['rkey'],
+				'fingerprint' => $fingerprint,
+			]
+		);
+	}
+
+	/**
+	 * Clear the cached publication record (e.g. on disconnect).
+	 */
+	public function clear(): void {
+		delete_option( self::OPTION_KEY );
+	}
+
+	/**
+	 * Build the publication record payload from WP settings + overrides.
+	 *
+	 * @param array<string,mixed> $connection
+	 * @return array<string,mixed>
+	 */
+	public function build_record( array $connection ): array {
+		$overrides = get_option( self::OVERRIDES_KEY, [] );
+		if ( ! is_array( $overrides ) ) {
+			$overrides = [];
+		}
+
+		$name        = $this->resolve_string( $overrides['name'] ?? null, get_bloginfo( 'name' ) );
+		$description = $this->resolve_string( $overrides['description'] ?? null, get_bloginfo( 'description' ) );
+
+		$record = [
+			'$type' => self::COLLECTION,
+			'url'   => untrailingslashit( home_url( '/' ) ),
+			'name'  => $name,
+		];
+
+		if ( '' !== $description ) {
+			$record['description'] = $description;
+		}
+
+		$icon_blob = $this->resolve_icon_blob( $overrides['icon_id'] ?? null, $connection );
+		if ( $icon_blob ) {
+			$record['icon'] = $icon_blob;
+		}
+
+		return $record;
+	}
+
+	/**
+	 * @param array<string,mixed> $connection
+	 * @return string|\WP_Error
+	 */
+	private function create( array $connection ) {
+		$record = $this->build_record( $connection );
+
+		$response = $this->api_client->create_record(
+			[
+				'repo'       => $connection['did'],
+				'collection' => self::COLLECTION,
+				'record'     => $record,
+			],
+			$connection['access_jwt'],
+			$connection['did']
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log->error(
+				__( 'Failed to create standard.site publication record: {message}', 'autoblue' ),
+				[ 'message' => $response->get_error_message() ]
+			);
+			return $response;
+		}
+
+		if ( empty( $response['uri'] ) ) {
+			return new \WP_Error( 'autoblue_invalid_publication_response', __( 'Publication record was created but no URI was returned.', 'autoblue' ) );
+		}
+
+		$rkey = $this->extract_rkey( (string) $response['uri'] );
+
+		update_option(
+			self::OPTION_KEY,
+			[
+				'did'         => $connection['did'],
+				'uri'         => (string) $response['uri'],
+				'cid'         => (string) ( $response['cid'] ?? '' ),
+				'rkey'        => $rkey,
+				'fingerprint' => $this->fingerprint( $record ),
+			]
+		);
+
+		$this->log->success(
+			__( 'Created standard.site publication record at {uri}.', 'autoblue' ),
+			[ 'uri' => $response['uri'] ]
+		);
+
+		return (string) $response['uri'];
+	}
+
+	/**
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function get_active_connection() {
+		$connections_manager = new ConnectionsManager();
+		$connections         = $connections_manager->get_all_connections();
+		if ( empty( $connections ) ) {
+			return new \WP_Error( 'autoblue_no_connection', __( 'No Bluesky connection found.', 'autoblue' ) );
+		}
+
+		$connection = $connections_manager->refresh_tokens( $connections[0]['did'] );
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+
+		return $connection;
+	}
+
+	private function resolve_string( $override, string $fallback ): string {
+		if ( is_string( $override ) && '' !== trim( $override ) ) {
+			return $override;
+		}
+		return $fallback;
+	}
+
+	/**
+	 * @param array<string,mixed> $connection
+	 * @return array<string,mixed>|null
+	 */
+	private function resolve_icon_blob( $override_id, array $connection ): ?array {
+		$attachment_id = is_int( $override_id ) && $override_id > 0
+			? $override_id
+			: (int) get_option( 'site_icon', 0 );
+
+		if ( $attachment_id <= 0 ) {
+			return null;
+		}
+
+		$path = get_attached_file( $attachment_id );
+		if ( ! $path || ! file_exists( $path ) ) {
+			return null;
+		}
+
+		$mime    = get_post_mime_type( $attachment_id );
+		$allowed = [ 'image/jpeg', 'image/png', 'image/webp' ];
+		if ( ! $mime || ! in_array( $mime, $allowed, true ) ) {
+			return null;
+		}
+
+		$compressor = new ImageCompressor( $path, $mime );
+		$bytes      = $compressor->compress_image();
+		if ( ! $bytes ) {
+			return null;
+		}
+
+		$blob = $this->api_client->upload_blob( $bytes, $mime, $connection['access_jwt'], $connection['did'] );
+		if ( is_wp_error( $blob ) ) {
+			$this->log->error(
+				__( 'Failed to upload publication icon: {message}', 'autoblue' ),
+				[ 'message' => $blob->get_error_message() ]
+			);
+			return null;
+		}
+
+		return $blob;
+	}
+
+	/**
+	 * @param array<string,mixed> $record
+	 */
+	private function fingerprint( array $record ): string {
+		return md5( (string) wp_json_encode( $record ) );
+	}
+
+	private function extract_rkey( string $uri ): string {
+		$parts = explode( '/', $uri );
+		return (string) end( $parts );
+	}
+}

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -125,6 +125,22 @@ class Publication {
 	}
 
 	/**
+	 * Get the cached publication strongRef ({ uri, cid }) without making network calls.
+	 *
+	 * @return array{uri:string,cid:string}|null
+	 */
+	public function get_strongref(): ?array {
+		$stored = get_option( self::OPTION_KEY, [] );
+		if ( empty( $stored['uri'] ) || empty( $stored['cid'] ) ) {
+			return null;
+		}
+		return [
+			'uri' => (string) $stored['uri'],
+			'cid' => (string) $stored['cid'],
+		];
+	}
+
+	/**
 	 * Reactively update the publication record when WP settings or overrides change.
 	 */
 	public function sync(): void {

--- a/includes/Standard/Publication.php
+++ b/includes/Standard/Publication.php
@@ -254,7 +254,7 @@ class Publication {
 			'accentForeground' => 'theme_accent_foreground',
 		];
 
-		$theme = [];
+		$theme = [ '$type' => 'site.standard.theme.basic' ];
 		foreach ( $mapping as $field => $key ) {
 			$rgb = $this->hex_to_rgb( $overrides[ $key ] ?? null );
 			if ( $rgb ) {
@@ -263,7 +263,7 @@ class Publication {
 		}
 
 		// Only return the theme if at least one colour was set.
-		return ! empty( $theme ) ? $theme : null;
+		return count( $theme ) > 1 ? $theme : null;
 	}
 
 	/**

--- a/includes/Standard/Verification.php
+++ b/includes/Standard/Verification.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Autoblue\Standard;
+
+use Autoblue\Utils;
+
+/**
+ * Serves the standard.site verification surface:
+ *  - /.well-known/site.standard.publication (plain-text publication AT-URI)
+ *  - <link rel="site.standard.document"> tags in singular post <head>s
+ */
+class Verification {
+	public const WELL_KNOWN_PATH = '/.well-known/site.standard.publication';
+	public const DOCUMENT_META   = 'autoblue_document';
+
+	public function register_hooks(): void {
+		add_action( 'parse_request', [ $this, 'maybe_serve_well_known' ] );
+		add_action( 'wp_head', [ $this, 'inject_document_link' ] );
+	}
+
+	public function maybe_serve_well_known(): void {
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) : '';
+		if ( self::WELL_KNOWN_PATH !== $request_uri ) {
+			return;
+		}
+
+		if ( ! Utils::is_standard_site_enabled() ) {
+			$this->respond_not_found();
+			return;
+		}
+
+		$uri = ( new Publication() )->get_uri();
+		if ( ! $uri ) {
+			$this->respond_not_found();
+			return;
+		}
+
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex' );
+		echo esc_html( $uri );
+		exit;
+	}
+
+	public function inject_document_link(): void {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$post_id = get_queried_object_id();
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$post_type = get_post_type( $post_id );
+		if ( ! $post_type || ! in_array( $post_type, Utils::get_enabled_post_types(), true ) ) {
+			return;
+		}
+
+		$document = get_post_meta( $post_id, self::DOCUMENT_META, true );
+		if ( ! is_array( $document ) || empty( $document['uri'] ) ) {
+			return;
+		}
+
+		printf(
+			'<link rel="site.standard.document" href="%s" />' . "\n",
+			esc_attr( (string) $document['uri'] )
+		);
+	}
+
+	private function respond_not_found(): void {
+		status_header( 404 );
+		nocache_headers();
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		echo 'Not found';
+		exit;
+	}
+}

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -56,4 +56,37 @@ class Utils {
 			error_log( $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
+
+	/**
+	 * Whether WordPress is installed at the root of its domain.
+	 *
+	 * The standard.site verification endpoint must live at
+	 * https://example.com/.well-known/site.standard.publication. WordPress can
+	 * only serve that path when home_url() and site_url() are both at '/'.
+	 */
+	public static function is_root_install(): bool {
+		$home_path = wp_parse_url( home_url( '/' ), PHP_URL_PATH );
+		$site_path = wp_parse_url( site_url( '/' ), PHP_URL_PATH );
+
+		return '/' === $home_path && '/' === $site_path;
+	}
+
+	/**
+	 * Whether the standard.site publishing feature is fully usable on this install.
+	 *
+	 * Requires the global toggle to be on, the install to be at the domain root,
+	 * and at least one Bluesky connection to write records under.
+	 */
+	public static function is_standard_site_enabled(): bool {
+		if ( ! get_option( 'autoblue_publish_documents_enabled', false ) ) {
+			return false;
+		}
+
+		if ( ! self::is_root_install() ) {
+			return false;
+		}
+
+		$connections = get_option( 'autoblue_connections', [] );
+		return ! empty( $connections );
+	}
 }

--- a/src/js/components/admin-page/index.js
+++ b/src/js/components/admin-page/index.js
@@ -11,9 +11,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import { Logo } from './../../icons';
 import Settings from './../settings';
 import Logs from './../logs';
+import Records from './../records';
+import useSettings from './../../hooks/use-settings';
 import styles from './styles.module.scss';
 
-const TABS = [ 'settings', 'logs' ];
+const TABS = [ 'settings', 'logs', 'records' ];
 
 const Notices = () => {
 	const { removeNotice } = useDispatch( noticesStore );
@@ -34,6 +36,8 @@ const Notices = () => {
 };
 
 const AdminPage = () => {
+	const { isStandardSiteEnabled } = useSettings();
+
 	const getInitialTab = () => {
 		const hash = window.location.hash.replace( '#', '' );
 		return TABS.includes( hash ) ? hash : 'settings';
@@ -46,6 +50,27 @@ const AdminPage = () => {
 		window.location.hash = tabName;
 	};
 
+	const tabs = [
+		{
+			name: 'settings',
+			title: __( 'Settings', 'autoblue' ),
+			className: 'autoblue-settings',
+		},
+		{
+			name: 'logs',
+			title: __( 'Logs', 'autoblue' ),
+			className: 'autoblue-logs',
+		},
+	];
+
+	if ( isStandardSiteEnabled ) {
+		tabs.push( {
+			name: 'records',
+			title: __( 'Records', 'autoblue' ),
+			className: 'autoblue-records',
+		} );
+	}
+
 	return (
 		<>
 			<div className={ styles.header }>
@@ -56,18 +81,7 @@ const AdminPage = () => {
 				className={ styles.tabs }
 				initialTabName={ activeTab }
 				onSelect={ handleTabChange }
-				tabs={ [
-					{
-						name: 'settings',
-						title: __( 'Settings', 'autoblue' ),
-						className: 'autoblue-settings',
-					},
-					{
-						name: 'logs',
-						title: __( 'Logs', 'autoblue' ),
-						className: 'autoblue-logs',
-					},
-				] }
+				tabs={ tabs }
 			>
 				{ ( tab ) => {
 					return (
@@ -81,6 +95,7 @@ const AdminPage = () => {
 							>
 								{ tab.name === 'settings' && <Settings /> }
 								{ tab.name === 'logs' && <Logs /> }
+								{ tab.name === 'records' && <Records /> }
 							</VStack>
 						</div>
 					);

--- a/src/js/components/admin-page/styles.module.scss
+++ b/src/js/components/admin-page/styles.module.scss
@@ -83,4 +83,8 @@
 	&.logs {
 		max-width: 900px;
 	}
+
+	&.records {
+		max-width: 600px;
+	}
 }

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -1,0 +1,199 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	Card,
+	CardBody,
+	Notice,
+	Spinner,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+const Records = () => {
+	const [ publication, setPublication ] = useState( null );
+	const [ documents, setDocuments ] = useState( [] );
+	const [ cursor, setCursor ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isLoadingMore, setIsLoadingMore ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const fetchPage = useCallback( async ( nextCursor = '' ) => {
+		const path = nextCursor
+			? `/autoblue/v1/standard/records?cursor=${ encodeURIComponent(
+					nextCursor
+			  ) }`
+			: '/autoblue/v1/standard/records';
+		return apiFetch( { path } );
+	}, [] );
+
+	useEffect( () => {
+		let cancelled = false;
+		( async () => {
+			try {
+				const response = await fetchPage( '' );
+				if ( cancelled ) return;
+				setPublication( response.publication ?? null );
+				setDocuments( response.documents ?? [] );
+				setCursor( response.cursor ?? null );
+			} catch ( e ) {
+				if ( cancelled ) return;
+				setError(
+					e?.message ||
+						__( 'Failed to load records.', 'autoblue' )
+				);
+			} finally {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			}
+		} )();
+		return () => {
+			cancelled = true;
+		};
+	}, [ fetchPage ] );
+
+	const loadMore = async () => {
+		if ( ! cursor || isLoadingMore ) return;
+		setIsLoadingMore( true );
+		try {
+			const response = await fetchPage( cursor );
+			setDocuments( ( prev ) => [
+				...prev,
+				...( response.documents ?? [] ),
+			] );
+			setCursor( response.cursor ?? null );
+		} catch ( e ) {
+			setError(
+				e?.message ||
+					__( 'Failed to load more documents.', 'autoblue' )
+			);
+		} finally {
+			setIsLoadingMore( false );
+		}
+	};
+
+	if ( isLoading ) {
+		return <Spinner />;
+	}
+
+	if ( error ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ error }
+			</Notice>
+		);
+	}
+
+	return (
+		<VStack spacing={ 5 }>
+			<Card>
+				<CardBody>
+					<VStack spacing={ 2 }>
+						<Text weight="600">
+							{ __( 'Publication', 'autoblue' ) }
+						</Text>
+						{ publication ? (
+							<>
+								<Text>
+									{ publication.value?.name ||
+										__(
+											'(no name)',
+											'autoblue'
+										) }
+								</Text>
+								{ publication.value?.description && (
+									<Text variant="muted">
+										{ publication.value.description }
+									</Text>
+								) }
+								<Text variant="muted">
+									{ publication.uri }
+								</Text>
+							</>
+						) : (
+							<Text variant="muted">
+								{ __(
+									'No publication record found on the PDS yet. It will be created on the next publish.',
+									'autoblue'
+								) }
+							</Text>
+						) }
+					</VStack>
+				</CardBody>
+			</Card>
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 3 }>
+						<Text weight="600">
+							{ __( 'Documents', 'autoblue' ) }
+							{ ' ' }
+							<Text variant="muted">
+								({ documents.length })
+							</Text>
+						</Text>
+						{ documents.length === 0 ? (
+							<Text variant="muted">
+								{ __(
+									'No document records on the PDS yet.',
+									'autoblue'
+								) }
+							</Text>
+						) : (
+							<VStack spacing={ 2 }>
+								{ documents.map( ( doc ) => (
+									<Card key={ doc.uri } size="small">
+										<CardBody>
+											<VStack spacing={ 1 }>
+												<Text weight="600">
+													{ doc.value?.title ||
+														__(
+															'(untitled)',
+															'autoblue'
+														) }
+												</Text>
+												{ doc.value?.description && (
+													<Text variant="muted">
+														{
+															doc.value
+																.description
+														}
+													</Text>
+												) }
+												<Text variant="muted">
+													{ doc.uri }
+												</Text>
+												{ doc.value?.publishedAt && (
+													<Text variant="muted">
+														{ new Date(
+															doc.value.publishedAt
+														).toLocaleString() }
+													</Text>
+												) }
+											</VStack>
+										</CardBody>
+									</Card>
+								) ) }
+							</VStack>
+						) }
+						{ cursor && (
+							<Button
+								variant="secondary"
+								onClick={ loadMore }
+								disabled={ isLoadingMore }
+							>
+								{ isLoadingMore
+									? __( 'Loading…', 'autoblue' )
+									: __( 'Load more', 'autoblue' ) }
+							</Button>
+						) }
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+};
+
+export default Records;

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -14,7 +15,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { update } from '@wordpress/icons';
+import { RefreshIcon } from '../../icons';
 import styles from './styles.module.scss';
 
 const extractDid = ( atUri = '' ) => {
@@ -155,15 +156,17 @@ const Records = () => {
 				className={ styles.toolbar }
 			>
 				<Button
-					variant="secondary"
-					icon={ update }
+					label={ __( 'Refresh records', 'autoblue' ) }
 					onClick={ handleRefresh }
 					disabled={ isRefreshing }
-				>
-					{ isRefreshing
-						? __( 'Refreshing…', 'autoblue' )
-						: __( 'Refresh', 'autoblue' ) }
-				</Button>
+					accessibleWhenDisabled
+					className={ clsx( {
+						[ styles.refresh ]: true,
+						[ styles.refreshing ]: isRefreshing,
+					} ) }
+					icon={ RefreshIcon }
+					size="compact"
+				/>
 			</HStack>
 
 			<BaseControl

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -8,6 +8,7 @@ import {
 	Button,
 	Card,
 	CardBody,
+	ColorIndicator,
 	Notice,
 	Spinner,
 	Tooltip,
@@ -36,6 +37,30 @@ const blobThumbnailUrl = ( did, blob ) => {
 
 const pdslsUrl = ( atUri ) =>
 	atUri ? `https://pdsls.dev/${ atUri }` : null;
+
+const rgbToHex = ( rgb ) => {
+	if ( ! rgb ) return null;
+	const { r, g, b } = rgb;
+	if (
+		typeof r !== 'number' ||
+		typeof g !== 'number' ||
+		typeof b !== 'number'
+	) {
+		return null;
+	}
+	const toHex = ( n ) =>
+		Math.max( 0, Math.min( 255, Math.round( n ) ) )
+			.toString( 16 )
+			.padStart( 2, '0' );
+	return `#${ toHex( r ) }${ toHex( g ) }${ toHex( b ) }`;
+};
+
+const THEME_FIELDS = [
+	{ key: 'background', label: 'Background' },
+	{ key: 'foreground', label: 'Foreground' },
+	{ key: 'accent', label: 'Accent' },
+	{ key: 'accentForeground', label: 'Accent foreground' },
+];
 
 const bskyPostUrl = ( bskyPostRef ) => {
 	const uri = bskyPostRef?.uri;
@@ -194,6 +219,42 @@ const Records = () => {
 										<Text variant="muted">
 											{ publication.value.description }
 										</Text>
+									) }
+									{ publication.value?.basicTheme && (
+										<HStack
+											spacing={ 2 }
+											alignment="left"
+											className={ styles.swatches }
+										>
+											{ THEME_FIELDS.map( ( field ) => {
+												const hex = rgbToHex(
+													publication.value
+														.basicTheme?.[
+														field.key
+													]
+												);
+												if ( ! hex ) return null;
+												return (
+													<Tooltip
+														key={ field.key }
+														text={ `${ field.label } — ${ hex }` }
+													>
+														<span
+															tabIndex={ 0 }
+															aria-label={
+																field.label
+															}
+														>
+															<ColorIndicator
+																colorValue={
+																	hex
+																}
+															/>
+														</span>
+													</Tooltip>
+												);
+											} ) }
+										</HStack>
 									) }
 									<HStack
 										spacing={ 3 }

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -9,6 +9,7 @@ import {
 	CardBody,
 	Notice,
 	Spinner,
+	Tooltip,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -47,14 +48,14 @@ const bskyPostUrl = ( bskyPostRef ) => {
 const RelativeDate = ( { iso } ) => {
 	if ( ! iso ) return null;
 	const date = new Date( iso );
+	const absolute = dateI18n( 'F j, Y g:i a', date );
 	return (
 		<Text variant="muted">
-			<time
-				dateTime={ iso }
-				title={ dateI18n( 'F j, Y g:i a', date ) }
-			>
-				{ humanTimeDiff( date ) }
-			</time>
+			<Tooltip text={ absolute }>
+				<time dateTime={ iso } tabIndex={ 0 }>
+					{ humanTimeDiff( date ) }
+				</time>
+			</Tooltip>
 		</Text>
 	);
 };
@@ -239,97 +240,86 @@ const Records = () => {
 					</Card>
 				) : (
 					<VStack spacing={ 3 }>
-						<Card>
-							<CardBody>
-								<VStack spacing={ 3 }>
-									{ documents.map( ( doc ) => {
-										const did = extractDid( doc.uri ?? '' );
-										const coverUrl = blobThumbnailUrl(
-											did,
-											doc.value?.coverImage
-										);
-										const bskyUrl = bskyPostUrl(
-											doc.value?.bskyPostRef
-										);
-										return (
-											<div
-												key={ doc.uri }
-												className={ styles.row }
+						{ documents.map( ( doc ) => {
+							const did = extractDid( doc.uri ?? '' );
+							const coverUrl = blobThumbnailUrl(
+								did,
+								doc.value?.coverImage
+							);
+							const bskyUrl = bskyPostUrl(
+								doc.value?.bskyPostRef
+							);
+							return (
+								<Card key={ doc.uri }>
+									<CardBody>
+										<div className={ styles.row }>
+											{ coverUrl && (
+												<img
+													className={ styles.cover }
+													src={ coverUrl }
+													alt=""
+												/>
+											) }
+											<VStack
+												spacing={ 1 }
+												className={ styles.meta }
 											>
-												{ coverUrl && (
-													<img
-														className={
-															styles.cover
-														}
-														src={ coverUrl }
-														alt=""
-													/>
-												) }
-												<VStack
-													spacing={ 1 }
-													className={ styles.meta }
-												>
-													<Text weight="600">
-														{ doc.value?.title ||
-															__(
-																'(untitled)',
-																'autoblue'
-															) }
-													</Text>
-													{ doc.value
-														?.description && (
-														<Text variant="muted">
-															{
-																doc.value
-																	.description
-															}
-														</Text>
-													) }
-													<RelativeDate
-														iso={
+												<Text weight="600">
+													{ doc.value?.title ||
+														__(
+															'(untitled)',
+															'autoblue'
+														) }
+												</Text>
+												{ doc.value?.description && (
+													<Text variant="muted">
+														{
 															doc.value
-																?.publishedAt
+																.description
 														}
-													/>
-													<HStack
-														spacing={ 3 }
-														alignment="left"
-														className={
-															styles.links
-														}
+													</Text>
+												) }
+												<RelativeDate
+													iso={
+														doc.value?.publishedAt
+													}
+												/>
+												<HStack
+													spacing={ 3 }
+													alignment="left"
+													className={ styles.links }
+												>
+													<a
+														href={ pdslsUrl(
+															doc.uri
+														) }
+														target="_blank"
+														rel="noreferrer"
 													>
+														{ __(
+															'View raw',
+															'autoblue'
+														) }
+													</a>
+													{ bskyUrl && (
 														<a
-															href={ pdslsUrl(
-																doc.uri
-															) }
+															href={ bskyUrl }
 															target="_blank"
 															rel="noreferrer"
 														>
 															{ __(
-																'View raw',
+																'View on Bluesky',
 																'autoblue'
 															) }
 														</a>
-														{ bskyUrl && (
-															<a
-																href={ bskyUrl }
-																target="_blank"
-																rel="noreferrer"
-															>
-																{ __(
-																	'View on Bluesky',
-																	'autoblue'
-																) }
-															</a>
-														) }
-													</HStack>
-												</VStack>
-											</div>
-										);
-									} ) }
-								</VStack>
-							</CardBody>
-						</Card>
+													) }
+												</HStack>
+											</VStack>
+										</div>
+									</CardBody>
+								</Card>
+							);
+						} ) }
 						{ cursor && (
 							<Button
 								variant="secondary"

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { dateI18n, humanTimeDiff } from '@wordpress/date';
 import {
 	BaseControl,
 	Button,
@@ -8,14 +9,21 @@ import {
 	CardBody,
 	Notice,
 	Spinner,
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { update } from '@wordpress/icons';
 import styles from './styles.module.scss';
 
 const extractDid = ( atUri = '' ) => {
 	const match = atUri.match( /^at:\/\/(did:[^/]+)/ );
 	return match ? match[ 1 ] : '';
+};
+
+const extractRkey = ( atUri = '' ) => {
+	const parts = atUri.split( '/' );
+	return parts.length ? parts[ parts.length - 1 ] : '';
 };
 
 const blobThumbnailUrl = ( did, blob ) => {
@@ -24,12 +32,40 @@ const blobThumbnailUrl = ( did, blob ) => {
 	return `https://cdn.bsky.app/img/feed_thumbnail/plain/${ did }/${ cid }@jpeg`;
 };
 
+const pdslsUrl = ( atUri ) =>
+	atUri ? `https://pdsls.dev/${ atUri }` : null;
+
+const bskyPostUrl = ( bskyPostRef ) => {
+	const uri = bskyPostRef?.uri;
+	if ( ! uri ) return null;
+	const did = extractDid( uri );
+	const rkey = extractRkey( uri );
+	if ( ! did || ! rkey ) return null;
+	return `https://bsky.app/profile/${ did }/post/${ rkey }`;
+};
+
+const RelativeDate = ( { iso } ) => {
+	if ( ! iso ) return null;
+	const date = new Date( iso );
+	return (
+		<Text variant="muted">
+			<time
+				dateTime={ iso }
+				title={ dateI18n( 'F j, Y g:i a', date ) }
+			>
+				{ humanTimeDiff( date ) }
+			</time>
+		</Text>
+	);
+};
+
 const Records = () => {
 	const [ publication, setPublication ] = useState( null );
 	const [ documents, setDocuments ] = useState( [] );
 	const [ cursor, setCursor ] = useState( null );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isLoadingMore, setIsLoadingMore ] = useState( false );
+	const [ isRefreshing, setIsRefreshing ] = useState( false );
 	const [ error, setError ] = useState( null );
 
 	const fetchPage = useCallback( async ( nextCursor = '' ) => {
@@ -41,31 +77,37 @@ const Records = () => {
 		return apiFetch( { path } );
 	}, [] );
 
+	const loadFirstPage = useCallback( async () => {
+		try {
+			const response = await fetchPage( '' );
+			setPublication( response.publication ?? null );
+			setDocuments( response.documents ?? [] );
+			setCursor( response.cursor ?? null );
+			setError( null );
+		} catch ( e ) {
+			setError(
+				e?.message || __( 'Failed to load records.', 'autoblue' )
+			);
+		}
+	}, [ fetchPage ] );
+
 	useEffect( () => {
 		let cancelled = false;
 		( async () => {
-			try {
-				const response = await fetchPage( '' );
-				if ( cancelled ) return;
-				setPublication( response.publication ?? null );
-				setDocuments( response.documents ?? [] );
-				setCursor( response.cursor ?? null );
-			} catch ( e ) {
-				if ( cancelled ) return;
-				setError(
-					e?.message ||
-						__( 'Failed to load records.', 'autoblue' )
-				);
-			} finally {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-				}
-			}
+			await loadFirstPage();
+			if ( ! cancelled ) setIsLoading( false );
 		} )();
 		return () => {
 			cancelled = true;
 		};
-	}, [ fetchPage ] );
+	}, [ loadFirstPage ] );
+
+	const handleRefresh = async () => {
+		if ( isRefreshing ) return;
+		setIsRefreshing( true );
+		await loadFirstPage();
+		setIsRefreshing( false );
+	};
 
 	const loadMore = async () => {
 		if ( ! cursor || isLoadingMore ) return;
@@ -107,6 +149,22 @@ const Records = () => {
 
 	return (
 		<>
+			<HStack
+				alignment="right"
+				className={ styles.toolbar }
+			>
+				<Button
+					variant="secondary"
+					icon={ update }
+					onClick={ handleRefresh }
+					disabled={ isRefreshing }
+				>
+					{ isRefreshing
+						? __( 'Refreshing…', 'autoblue' )
+						: __( 'Refresh', 'autoblue' ) }
+				</Button>
+			</HStack>
+
 			<BaseControl
 				__nextHasNoMarginBottom
 				label={ __( 'Publication', 'autoblue' ) }
@@ -123,7 +181,7 @@ const Records = () => {
 										alt=""
 									/>
 								) }
-								<VStack spacing={ 1 }>
+								<VStack spacing={ 1 } className={ styles.meta }>
 									<Text weight="600">
 										{ publication.value?.name ||
 											__( '(no name)', 'autoblue' ) }
@@ -133,9 +191,22 @@ const Records = () => {
 											{ publication.value.description }
 										</Text>
 									) }
-									<Text variant="muted">
-										{ publication.uri }
-									</Text>
+									<HStack
+										spacing={ 3 }
+										alignment="left"
+										className={ styles.links }
+									>
+										<a
+											href={ pdslsUrl( publication.uri ) }
+											target="_blank"
+											rel="noreferrer"
+										>
+											{ __(
+												'View raw',
+												'autoblue'
+											) }
+										</a>
+									</HStack>
 								</VStack>
 							</div>
 						) : (
@@ -172,12 +243,13 @@ const Records = () => {
 							<CardBody>
 								<VStack spacing={ 3 }>
 									{ documents.map( ( doc ) => {
-										const did = extractDid(
-											doc.uri ?? ''
-										);
+										const did = extractDid( doc.uri ?? '' );
 										const coverUrl = blobThumbnailUrl(
 											did,
 											doc.value?.coverImage
+										);
+										const bskyUrl = bskyPostUrl(
+											doc.value?.bskyPostRef
 										);
 										return (
 											<div
@@ -193,7 +265,10 @@ const Records = () => {
 														alt=""
 													/>
 												) }
-												<VStack spacing={ 1 }>
+												<VStack
+													spacing={ 1 }
+													className={ styles.meta }
+												>
 													<Text weight="600">
 														{ doc.value?.title ||
 															__(
@@ -210,17 +285,44 @@ const Records = () => {
 															}
 														</Text>
 													) }
-													<Text variant="muted">
-														{ doc.uri }
-													</Text>
-													{ doc.value
-														?.publishedAt && (
-														<Text variant="muted">
-															{ new Date(
-																doc.value.publishedAt
-															).toLocaleString() }
-														</Text>
-													) }
+													<RelativeDate
+														iso={
+															doc.value
+																?.publishedAt
+														}
+													/>
+													<HStack
+														spacing={ 3 }
+														alignment="left"
+														className={
+															styles.links
+														}
+													>
+														<a
+															href={ pdslsUrl(
+																doc.uri
+															) }
+															target="_blank"
+															rel="noreferrer"
+														>
+															{ __(
+																'View raw',
+																'autoblue'
+															) }
+														</a>
+														{ bskyUrl && (
+															<a
+																href={ bskyUrl }
+																target="_blank"
+																rel="noreferrer"
+															>
+																{ __(
+																	'View on Bluesky',
+																	'autoblue'
+																) }
+															</a>
+														) }
+													</HStack>
 												</VStack>
 											</div>
 										);

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import {
+	BaseControl,
 	Button,
 	Card,
 	CardBody,
@@ -10,6 +11,18 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import styles from './styles.module.scss';
+
+const extractDid = ( atUri = '' ) => {
+	const match = atUri.match( /^at:\/\/(did:[^/]+)/ );
+	return match ? match[ 1 ] : '';
+};
+
+const blobThumbnailUrl = ( did, blob ) => {
+	const cid = blob?.ref?.$link;
+	if ( ! did || ! cid ) return null;
+	return `https://cdn.bsky.app/img/feed_thumbnail/plain/${ did }/${ cid }@jpeg`;
+};
 
 const Records = () => {
 	const [ publication, setPublication ] = useState( null );
@@ -86,32 +99,45 @@ const Records = () => {
 		);
 	}
 
+	const publicationDid = extractDid( publication?.uri ?? '' );
+	const publicationIconUrl = blobThumbnailUrl(
+		publicationDid,
+		publication?.value?.icon
+	);
+
 	return (
-		<VStack spacing={ 5 }>
-			<Card>
-				<CardBody>
-					<VStack spacing={ 2 }>
-						<Text weight="600">
-							{ __( 'Publication', 'autoblue' ) }
-						</Text>
+		<>
+			<BaseControl
+				__nextHasNoMarginBottom
+				label={ __( 'Publication', 'autoblue' ) }
+				id="autoblue-records-publication"
+			>
+				<Card>
+					<CardBody>
 						{ publication ? (
-							<>
-								<Text>
-									{ publication.value?.name ||
-										__(
-											'(no name)',
-											'autoblue'
-										) }
-								</Text>
-								{ publication.value?.description && (
-									<Text variant="muted">
-										{ publication.value.description }
-									</Text>
+							<div className={ styles.row }>
+								{ publicationIconUrl && (
+									<img
+										className={ styles.icon }
+										src={ publicationIconUrl }
+										alt=""
+									/>
 								) }
-								<Text variant="muted">
-									{ publication.uri }
-								</Text>
-							</>
+								<VStack spacing={ 1 }>
+									<Text weight="600">
+										{ publication.value?.name ||
+											__( '(no name)', 'autoblue' ) }
+									</Text>
+									{ publication.value?.description && (
+										<Text variant="muted">
+											{ publication.value.description }
+										</Text>
+									) }
+									<Text variant="muted">
+										{ publication.uri }
+									</Text>
+								</VStack>
+							</div>
 						) : (
 							<Text variant="muted">
 								{ __(
@@ -120,64 +146,88 @@ const Records = () => {
 								) }
 							</Text>
 						) }
-					</VStack>
-				</CardBody>
-			</Card>
+					</CardBody>
+				</Card>
+			</BaseControl>
 
-			<Card>
-				<CardBody>
-					<VStack spacing={ 3 }>
-						<Text weight="600">
-							{ __( 'Documents', 'autoblue' ) }
-							{ ' ' }
-							<Text variant="muted">
-								({ documents.length })
-							</Text>
-						</Text>
-						{ documents.length === 0 ? (
+			<BaseControl
+				__nextHasNoMarginBottom
+				label={ __( 'Documents', 'autoblue' ) }
+				id="autoblue-records-documents"
+			>
+				{ documents.length === 0 ? (
+					<Card>
+						<CardBody>
 							<Text variant="muted">
 								{ __(
 									'No document records on the PDS yet.',
 									'autoblue'
 								) }
 							</Text>
-						) : (
-							<VStack spacing={ 2 }>
-								{ documents.map( ( doc ) => (
-									<Card key={ doc.uri } size="small">
-										<CardBody>
-											<VStack spacing={ 1 }>
-												<Text weight="600">
-													{ doc.value?.title ||
-														__(
-															'(untitled)',
-															'autoblue'
-														) }
-												</Text>
-												{ doc.value?.description && (
-													<Text variant="muted">
-														{
-															doc.value
-																.description
+						</CardBody>
+					</Card>
+				) : (
+					<VStack spacing={ 3 }>
+						<Card>
+							<CardBody>
+								<VStack spacing={ 3 }>
+									{ documents.map( ( doc ) => {
+										const did = extractDid(
+											doc.uri ?? ''
+										);
+										const coverUrl = blobThumbnailUrl(
+											did,
+											doc.value?.coverImage
+										);
+										return (
+											<div
+												key={ doc.uri }
+												className={ styles.row }
+											>
+												{ coverUrl && (
+													<img
+														className={
+															styles.cover
 														}
-													</Text>
+														src={ coverUrl }
+														alt=""
+													/>
 												) }
-												<Text variant="muted">
-													{ doc.uri }
-												</Text>
-												{ doc.value?.publishedAt && (
+												<VStack spacing={ 1 }>
+													<Text weight="600">
+														{ doc.value?.title ||
+															__(
+																'(untitled)',
+																'autoblue'
+															) }
+													</Text>
+													{ doc.value
+														?.description && (
+														<Text variant="muted">
+															{
+																doc.value
+																	.description
+															}
+														</Text>
+													) }
 													<Text variant="muted">
-														{ new Date(
-															doc.value.publishedAt
-														).toLocaleString() }
+														{ doc.uri }
 													</Text>
-												) }
-											</VStack>
-										</CardBody>
-									</Card>
-								) ) }
-							</VStack>
-						) }
+													{ doc.value
+														?.publishedAt && (
+														<Text variant="muted">
+															{ new Date(
+																doc.value.publishedAt
+															).toLocaleString() }
+														</Text>
+													) }
+												</VStack>
+											</div>
+										);
+									} ) }
+								</VStack>
+							</CardBody>
+						</Card>
 						{ cursor && (
 							<Button
 								variant="secondary"
@@ -190,9 +240,9 @@ const Records = () => {
 							</Button>
 						) }
 					</VStack>
-				</CardBody>
-			</Card>
-		</VStack>
+				) }
+			</BaseControl>
+		</>
 	);
 };
 

--- a/src/js/components/records/index.js
+++ b/src/js/components/records/index.js
@@ -172,7 +172,7 @@ const Records = () => {
 				id="autoblue-records-publication"
 			>
 				<Card>
-					<CardBody>
+					<CardBody className={ styles.card }>
 						{ publication ? (
 							<div className={ styles.row }>
 								{ publicationIconUrl && (
@@ -229,7 +229,7 @@ const Records = () => {
 			>
 				{ documents.length === 0 ? (
 					<Card>
-						<CardBody>
+						<CardBody className={ styles.card }>
 							<Text variant="muted">
 								{ __(
 									'No document records on the PDS yet.',
@@ -251,7 +251,7 @@ const Records = () => {
 							);
 							return (
 								<Card key={ doc.uri }>
-									<CardBody>
+									<CardBody className={ styles.card }>
 										<div className={ styles.row }>
 											{ coverUrl && (
 												<img

--- a/src/js/components/records/styles.module.scss
+++ b/src/js/components/records/styles.module.scss
@@ -44,6 +44,18 @@
 	margin-bottom: 8px;
 }
 
+@keyframes rotate {
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+.refreshing {
+	svg {
+		animation: rotate 0.6s linear infinite;
+	}
+}
+
 .card.card {
 	padding: 20px;
 

--- a/src/js/components/records/styles.module.scss
+++ b/src/js/components/records/styles.module.scss
@@ -40,6 +40,10 @@
 	}
 }
 
+.swatches {
+	margin-top: 4px;
+}
+
 .toolbar {
 	margin-bottom: 8px;
 }

--- a/src/js/components/records/styles.module.scss
+++ b/src/js/components/records/styles.module.scss
@@ -1,0 +1,23 @@
+.row {
+	display: flex;
+	gap: 16px;
+	align-items: flex-start;
+}
+
+.icon {
+	width: 48px;
+	height: 48px;
+	border-radius: 6px;
+	object-fit: cover;
+	background: #f1f1f1;
+	flex-shrink: 0;
+}
+
+.cover {
+	width: 80px;
+	height: 60px;
+	border-radius: 4px;
+	object-fit: cover;
+	background: #f1f1f1;
+	flex-shrink: 0;
+}

--- a/src/js/components/records/styles.module.scss
+++ b/src/js/components/records/styles.module.scss
@@ -4,6 +4,11 @@
 	align-items: flex-start;
 }
 
+.meta {
+	min-width: 0;
+	flex: 1;
+}
+
 .icon {
 	width: 48px;
 	height: 48px;
@@ -20,4 +25,21 @@
 	object-fit: cover;
 	background: #f1f1f1;
 	flex-shrink: 0;
+}
+
+.links {
+	font-size: 12px;
+	margin-top: 4px;
+
+	a {
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+}
+
+.toolbar {
+	margin-bottom: 8px;
 }

--- a/src/js/components/records/styles.module.scss
+++ b/src/js/components/records/styles.module.scss
@@ -43,3 +43,11 @@
 .toolbar {
 	margin-bottom: 8px;
 }
+
+.card.card {
+	padding: 20px;
+
+	@media screen and (max-width: 500px) {
+		padding: 10px;
+	}
+}

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
+	Button,
 	Card,
 	CardBody,
 	CheckboxControl,
@@ -8,10 +9,15 @@ import {
 	Spinner,
 	TextControl,
 	TextareaControl,
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import NoAccountsPlaceholder from './../no-accounts-placeholder';
 import AccountList from './../account-list';
 import SettingToggle from './../setting-toggle';
@@ -32,10 +38,39 @@ const Settings = () => {
 		isLoadingStandardSite,
 		setIsStandardSiteEnabled,
 		publicationOverrides,
-		setPublicationOverride,
+		savePublicationOverrides,
 		standardSitePublication,
 		isRootInstall,
+		isSaving,
 	} = useSettings();
+
+	const savedName = publicationOverrides.name ?? '';
+	const savedDescription = publicationOverrides.description ?? '';
+
+	const [ draftName, setDraftName ] = useState( savedName );
+	const [ draftDescription, setDraftDescription ] = useState( savedDescription );
+
+	// Re-sync drafts when the saved overrides change (initial load + after our own save).
+	useEffect( () => {
+		setDraftName( savedName );
+	}, [ savedName ] );
+	useEffect( () => {
+		setDraftDescription( savedDescription );
+	}, [ savedDescription ] );
+
+	const isPublicationDirty =
+		draftName !== savedName || draftDescription !== savedDescription;
+
+	const handleUpdatePublication = () => {
+		const next = {};
+		if ( draftName.trim() !== '' ) {
+			next.name = draftName;
+		}
+		if ( draftDescription.trim() !== '' ) {
+			next.description = draftDescription;
+		}
+		savePublicationOverrides( next );
+	};
 
 	return (
 		<>
@@ -158,9 +193,7 @@ const Settings = () => {
 													'Publication name',
 													'autoblue'
 												) }
-												value={
-													publicationOverrides.name ?? ''
-												}
+												value={ draftName }
 												placeholder={
 													standardSitePublication.siteName ||
 													''
@@ -169,12 +202,7 @@ const Settings = () => {
 													'Leave empty to use the WordPress site title.',
 													'autoblue'
 												) }
-												onChange={ ( value ) =>
-													setPublicationOverride(
-														'name',
-														value
-													)
-												}
+												onChange={ setDraftName }
 											/>
 											<TextareaControl
 												__nextHasNoMarginBottom
@@ -182,10 +210,7 @@ const Settings = () => {
 													'Publication description',
 													'autoblue'
 												) }
-												value={
-													publicationOverrides.description ??
-													''
-												}
+												value={ draftDescription }
 												placeholder={
 													standardSitePublication.siteDesc ||
 													''
@@ -194,12 +219,7 @@ const Settings = () => {
 													'Leave empty to use the WordPress site tagline.',
 													'autoblue'
 												) }
-												onChange={ ( value ) =>
-													setPublicationOverride(
-														'description',
-														value
-													)
-												}
+												onChange={ setDraftDescription }
 											/>
 											<TextControl
 												__nextHasNoMarginBottom
@@ -226,6 +246,24 @@ const Settings = () => {
 													readOnly
 												/>
 											) }
+											<HStack alignment="left">
+												<Button
+													variant="primary"
+													onClick={
+														handleUpdatePublication
+													}
+													disabled={
+														! isPublicationDirty ||
+														isSaving
+													}
+												>
+													{ __(
+														'Update publication',
+														'autoblue'
+													) }
+												</Button>
+												{ isSaving && <Spinner /> }
+											</HStack>
 										</VStack>
 									) }
 								</VStack>

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -18,7 +18,6 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
-import { MediaUpload, MediaUploadCheck } from '@wordpress/media-utils';
 import NoAccountsPlaceholder from './../no-accounts-placeholder';
 import AccountList from './../account-list';
 import SettingToggle from './../setting-toggle';
@@ -122,9 +121,31 @@ const Settings = () => {
 		savePublicationOverrides( next );
 	};
 
-	const handleSelectIcon = ( media ) => {
-		setDraftIconId( media.id );
-		setDraftIconUrl( media.url || '' );
+	const openIconPicker = () => {
+		if ( ! window.wp?.media ) {
+			return;
+		}
+		const frame = window.wp.media( {
+			title: __( 'Select publication icon', 'autoblue' ),
+			button: { text: __( 'Use this icon', 'autoblue' ) },
+			library: { type: 'image' },
+			multiple: false,
+		} );
+		frame.on( 'select', () => {
+			const attachment = frame
+				.state()
+				.get( 'selection' )
+				.first()
+				.toJSON();
+			setDraftIconId( attachment.id );
+			setDraftIconUrl(
+				attachment.sizes?.thumbnail?.url ||
+					attachment.sizes?.medium?.url ||
+					attachment.url ||
+					''
+			);
+		} );
+		frame.open();
 	};
 
 	const handleRemoveIcon = () => {
@@ -324,40 +345,22 @@ const Settings = () => {
 															}
 														/>
 													) }
-													<MediaUploadCheck>
-														<MediaUpload
-															onSelect={
-																handleSelectIcon
-															}
-															allowedTypes={ [
-																'image',
-															] }
-															value={
-																draftIconId ||
-																undefined
-															}
-															render={ ( {
-																open,
-															} ) => (
-																<Button
-																	variant="secondary"
-																	onClick={
-																		open
-																	}
-																>
-																	{ draftIconId
-																		? __(
-																				'Replace icon',
-																				'autoblue'
-																		  )
-																		: __(
-																				'Choose icon',
-																				'autoblue'
-																		  ) }
-																</Button>
-															) }
-														/>
-													</MediaUploadCheck>
+													<Button
+														variant="secondary"
+														onClick={
+															openIconPicker
+														}
+													>
+														{ draftIconId
+															? __(
+																	'Replace icon',
+																	'autoblue'
+															  )
+															: __(
+																	'Choose icon',
+																	'autoblue'
+															  ) }
+													</Button>
 													{ draftIconId && (
 														<Button
 															variant="tertiary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -4,7 +4,10 @@ import {
 	Card,
 	CardBody,
 	CheckboxControl,
+	Notice,
 	Spinner,
+	TextControl,
+	TextareaControl,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -25,6 +28,13 @@ const Settings = () => {
 		isLoadingPostTypes,
 		availablePostTypes,
 		togglePostType,
+		isStandardSiteEnabled,
+		isLoadingStandardSite,
+		setIsStandardSiteEnabled,
+		publicationOverrides,
+		setPublicationOverride,
+		standardSitePublication,
+		isRootInstall,
 	} = useSettings();
 
 	return (
@@ -100,6 +110,126 @@ const Settings = () => {
 									</VStack>
 								) }
 							</VStack>
+						</CardBody>
+					</Card>
+				</BaseControl>
+			) }
+			{ hasAccounts && (
+				<BaseControl
+					__nextHasNoMarginBottom
+					label={ __( 'standard.site', 'autoblue' ) }
+					id="autoblue-standard-site"
+				>
+					<Card>
+						<CardBody className={ styles.card }>
+							{ ! isRootInstall ? (
+								<Notice
+									status="info"
+									isDismissible={ false }
+								>
+									{ __(
+										'standard.site requires WordPress to be installed at your domain root. This install lives in a subdirectory, so the feature is unavailable.',
+										'autoblue'
+									) }
+								</Notice>
+							) : (
+								<VStack spacing={ 3 }>
+									{ isLoadingStandardSite ? (
+										<Spinner />
+									) : (
+										<SettingToggle
+											label={ __(
+												'Publish posts as standard.site documents',
+												'autoblue'
+											) }
+											help={ __(
+												'Also writes a site.standard.document record to your PDS for every post shared to Bluesky, so other AT-aware readers can discover it.',
+												'autoblue'
+											) }
+											checked={ isStandardSiteEnabled }
+											onChange={ setIsStandardSiteEnabled }
+										/>
+									) }
+									{ isStandardSiteEnabled && (
+										<VStack spacing={ 3 }>
+											<TextControl
+												__nextHasNoMarginBottom
+												label={ __(
+													'Publication name',
+													'autoblue'
+												) }
+												value={
+													publicationOverrides.name ?? ''
+												}
+												placeholder={
+													standardSitePublication.siteName ||
+													''
+												}
+												help={ __(
+													'Leave empty to use the WordPress site title.',
+													'autoblue'
+												) }
+												onChange={ ( value ) =>
+													setPublicationOverride(
+														'name',
+														value
+													)
+												}
+											/>
+											<TextareaControl
+												__nextHasNoMarginBottom
+												label={ __(
+													'Publication description',
+													'autoblue'
+												) }
+												value={
+													publicationOverrides.description ??
+													''
+												}
+												placeholder={
+													standardSitePublication.siteDesc ||
+													''
+												}
+												help={ __(
+													'Leave empty to use the WordPress site tagline.',
+													'autoblue'
+												) }
+												onChange={ ( value ) =>
+													setPublicationOverride(
+														'description',
+														value
+													)
+												}
+											/>
+											<TextControl
+												__nextHasNoMarginBottom
+												label={ __(
+													'Publication URL',
+													'autoblue'
+												) }
+												value={
+													standardSitePublication.url ||
+													''
+												}
+												readOnly
+											/>
+											{ standardSitePublication.publishedUri && (
+												<TextControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Publication record (AT-URI)',
+														'autoblue'
+													) }
+													value={
+														standardSitePublication.publishedUri
+													}
+													readOnly
+												/>
+											) }
+										</VStack>
+									) }
+								</VStack>
+							) }
 						</CardBody>
 					</Card>
 				</BaseControl>

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -505,10 +505,7 @@ const Settings = () => {
 																	handleThemeChange
 																}
 																canOnlyChangeValues
-																paletteLabel={ __(
-																	'Theme colors',
-																	'autoblue'
-																) }
+																paletteLabel=""
 																popoverProps={ {
 																	offset: 8,
 																	placement:

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -444,12 +444,6 @@ const Settings = () => {
 													readOnly
 												/>
 											) }
-											<Text variant="muted">
-												{ __(
-													'Theme colors are used by standard.site readers to style your publication.',
-													'autoblue'
-												) }
-											</Text>
 											<PaletteEdit
 												colors={ themePalette }
 												onChange={ handleThemeChange }
@@ -463,6 +457,12 @@ const Settings = () => {
 													placement: 'bottom-start',
 												} }
 											/>
+											<Text variant="muted">
+												{ __(
+													'Theme colors are used by standard.site readers to style your publication.',
+													'autoblue'
+												) }
+											</Text>
 											<HStack alignment="left">
 												<Button
 													variant="primary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -473,41 +473,58 @@ const Settings = () => {
 													readOnly
 												/>
 											) }
-											<ToggleControl
+											<BaseControl
 												__nextHasNoMarginBottom
 												label={ __(
-													'Customize publication colors',
+													'Publication colors',
 													'autoblue'
 												) }
-												checked={ draftHasTheme }
-												onChange={ handleToggleTheme }
-											/>
-											{ draftHasTheme && (
-												<>
-													<PaletteEdit
-														colors={ themePalette }
-														onChange={
-															handleThemeChange
+												id="autoblue-publication-colors"
+											>
+												<VStack spacing={ 3 }>
+													<ToggleControl
+														__nextHasNoMarginBottom
+														label={ __(
+															'Customize publication colors',
+															'autoblue'
+														) }
+														checked={
+															draftHasTheme
 														}
-														canOnlyChangeValues
-														paletteLabel={ __(
-															'Theme colors',
-															'autoblue'
-														) }
-														popoverProps={ {
-															offset: 8,
-															placement:
-																'bottom-start',
-														} }
+														onChange={
+															handleToggleTheme
+														}
 													/>
-													<Text variant="muted">
-														{ __(
-															'Theme colors are used by standard.site readers to style your publication.',
-															'autoblue'
-														) }
-													</Text>
-												</>
-											) }
+													{ draftHasTheme && (
+														<>
+															<PaletteEdit
+																colors={
+																	themePalette
+																}
+																onChange={
+																	handleThemeChange
+																}
+																canOnlyChangeValues
+																paletteLabel={ __(
+																	'Theme colors',
+																	'autoblue'
+																) }
+																popoverProps={ {
+																	offset: 8,
+																	placement:
+																		'bottom-start',
+																} }
+															/>
+															<Text variant="muted">
+																{ __(
+																	'Theme colors are used by standard.site readers to style your publication.',
+																	'autoblue'
+																) }
+															</Text>
+														</>
+													) }
+												</VStack>
+											</BaseControl>
 											<HStack alignment="left">
 												<Button
 													variant="primary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -388,19 +388,6 @@ const Settings = () => {
 												}
 												readOnly
 											/>
-											{ standardSitePublication.publishedUri && (
-												<TextControl
-													__nextHasNoMarginBottom
-													label={ __(
-														'Publication record (AT-URI)',
-														'autoblue'
-													) }
-													value={
-														standardSitePublication.publishedUri
-													}
-													readOnly
-												/>
-											) }
 											<div className={ styles.split }>
 												<BaseControl
 													__nextHasNoMarginBottom
@@ -498,21 +485,27 @@ const Settings = () => {
 														/>
 														{ draftHasTheme && (
 															<>
-																<PaletteEdit
-																	colors={
-																		themePalette
+																<div
+																	className={
+																		styles.palette
 																	}
-																	onChange={
-																		handleThemeChange
-																	}
-																	canOnlyChangeValues
-																	paletteLabel=""
-																	popoverProps={ {
-																		offset: 8,
-																		placement:
-																			'bottom-start',
-																	} }
-																/>
+																>
+																	<PaletteEdit
+																		colors={
+																			themePalette
+																		}
+																		onChange={
+																			handleThemeChange
+																		}
+																		canOnlyChangeValues
+																		paletteLabel=""
+																		popoverProps={ {
+																			offset: 8,
+																			placement:
+																				'bottom-start',
+																		} }
+																	/>
+																</div>
 																<Text variant="muted">
 																	{ __(
 																		'Theme colors are used by standard.site readers to style your publication.',

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -9,6 +9,7 @@ import {
 	Spinner,
 	TextControl,
 	TextareaControl,
+	ToggleControl,
 	__experimentalHStack as HStack,
 	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalText as Text,
@@ -87,14 +88,40 @@ const Settings = () => {
 		setDraftThemeAccentFg( savedThemeAccentFg );
 	}, [ savedThemeAccentFg ] );
 
+	const savedHasTheme = Boolean(
+		savedThemeBackground ||
+			savedThemeForeground ||
+			savedThemeAccent ||
+			savedThemeAccentFg
+	);
+	const [ draftHasTheme, setDraftHasTheme ] = useState( savedHasTheme );
+	useEffect( () => {
+		setDraftHasTheme( savedHasTheme );
+	}, [ savedHasTheme ] );
+
 	const isPublicationDirty =
 		draftName !== savedName ||
 		draftDescription !== savedDescription ||
 		( draftIconId || null ) !== ( savedIconId || null ) ||
-		draftThemeBackground !== savedThemeBackground ||
-		draftThemeForeground !== savedThemeForeground ||
-		draftThemeAccent !== savedThemeAccent ||
-		draftThemeAccentFg !== savedThemeAccentFg;
+		draftHasTheme !== savedHasTheme ||
+		( draftHasTheme &&
+			( draftThemeBackground !== savedThemeBackground ||
+				draftThemeForeground !== savedThemeForeground ||
+				draftThemeAccent !== savedThemeAccent ||
+				draftThemeAccentFg !== savedThemeAccentFg ) );
+
+	const handleToggleTheme = ( isOn ) => {
+		setDraftHasTheme( isOn );
+		if ( isOn ) {
+			// Seed sensible defaults for any slot that's still empty.
+			if ( ! draftThemeBackground ) setDraftThemeBackground( '#ffffff' );
+			if ( ! draftThemeForeground ) setDraftThemeForeground( '#111111' );
+			if ( ! draftThemeAccent ) setDraftThemeAccent( '#0073aa' );
+			if ( ! draftThemeAccentFg ) setDraftThemeAccentFg( '#ffffff' );
+		}
+		// Leave drafts populated when toggling off so flipping back on
+		// restores the user's last picks. The save handler gates on draftHasTheme.
+	};
 
 	const handleUpdatePublication = () => {
 		const next = {};
@@ -107,17 +134,19 @@ const Settings = () => {
 		if ( draftIconId ) {
 			next.icon_id = Number( draftIconId );
 		}
-		if ( draftThemeBackground.trim() !== '' ) {
-			next.theme_background = draftThemeBackground;
-		}
-		if ( draftThemeForeground.trim() !== '' ) {
-			next.theme_foreground = draftThemeForeground;
-		}
-		if ( draftThemeAccent.trim() !== '' ) {
-			next.theme_accent = draftThemeAccent;
-		}
-		if ( draftThemeAccentFg.trim() !== '' ) {
-			next.theme_accent_foreground = draftThemeAccentFg;
+		if ( draftHasTheme ) {
+			if ( draftThemeBackground.trim() !== '' ) {
+				next.theme_background = draftThemeBackground;
+			}
+			if ( draftThemeForeground.trim() !== '' ) {
+				next.theme_foreground = draftThemeForeground;
+			}
+			if ( draftThemeAccent.trim() !== '' ) {
+				next.theme_accent = draftThemeAccent;
+			}
+			if ( draftThemeAccentFg.trim() !== '' ) {
+				next.theme_accent_foreground = draftThemeAccentFg;
+			}
 		}
 		savePublicationOverrides( next );
 	};
@@ -444,25 +473,41 @@ const Settings = () => {
 													readOnly
 												/>
 											) }
-											<PaletteEdit
-												colors={ themePalette }
-												onChange={ handleThemeChange }
-												canOnlyChangeValues
-												paletteLabel={ __(
-													'Theme colors',
+											<ToggleControl
+												__nextHasNoMarginBottom
+												label={ __(
+													'Customize publication colors',
 													'autoblue'
 												) }
-												popoverProps={ {
-													offset: 8,
-													placement: 'bottom-start',
-												} }
+												checked={ draftHasTheme }
+												onChange={ handleToggleTheme }
 											/>
-											<Text variant="muted">
-												{ __(
-													'Theme colors are used by standard.site readers to style your publication.',
-													'autoblue'
-												) }
-											</Text>
+											{ draftHasTheme && (
+												<>
+													<PaletteEdit
+														colors={ themePalette }
+														onChange={
+															handleThemeChange
+														}
+														canOnlyChangeValues
+														paletteLabel={ __(
+															'Theme colors',
+															'autoblue'
+														) }
+														popoverProps={ {
+															offset: 8,
+															placement:
+																'bottom-start',
+														} }
+													/>
+													<Text variant="muted">
+														{ __(
+															'Theme colors are used by standard.site readers to style your publication.',
+															'autoblue'
+														) }
+													</Text>
+												</>
+											) }
 											<HStack alignment="left">
 												<Button
 													variant="primary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -10,6 +10,7 @@ import {
 	TextControl,
 	TextareaControl,
 	__experimentalHStack as HStack,
+	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -155,6 +156,46 @@ const Settings = () => {
 
 	const currentIconUrl =
 		draftIconUrl || standardSitePublication.siteIconUrl || '';
+
+	const themePalette = [
+		{
+			slug: 'background',
+			name: __( 'Background', 'autoblue' ),
+			color: draftThemeBackground || '#ffffff',
+		},
+		{
+			slug: 'foreground',
+			name: __( 'Foreground', 'autoblue' ),
+			color: draftThemeForeground || '#111111',
+		},
+		{
+			slug: 'accent',
+			name: __( 'Accent', 'autoblue' ),
+			color: draftThemeAccent || '#0073aa',
+		},
+		{
+			slug: 'accent_foreground',
+			name: __( 'Accent foreground', 'autoblue' ),
+			color: draftThemeAccentFg || '#ffffff',
+		},
+	];
+
+	const themeSetters = {
+		background: setDraftThemeBackground,
+		foreground: setDraftThemeForeground,
+		accent: setDraftThemeAccent,
+		accent_foreground: setDraftThemeAccentFg,
+	};
+
+	const handleThemeChange = ( nextPalette ) => {
+		if ( ! Array.isArray( nextPalette ) ) return;
+		nextPalette.forEach( ( entry ) => {
+			const setter = themeSetters[ entry.slug ];
+			if ( setter ) {
+				setter( entry.color || '' );
+			}
+		} );
+	};
 
 	return (
 		<>
@@ -404,68 +445,23 @@ const Settings = () => {
 											) }
 											<Text variant="muted">
 												{ __(
-													'Theme colors are used by standard.site readers to style your publication. Leave blank to omit.',
+													'Theme colors are used by standard.site readers to style your publication.',
 													'autoblue'
 												) }
 											</Text>
-											<HStack spacing={ 3 } alignment="top">
-												<TextControl
-													__nextHasNoMarginBottom
-													label={ __(
-														'Background',
-														'autoblue'
-													) }
-													value={
-														draftThemeBackground
-													}
-													placeholder="#ffffff"
-													onChange={
-														setDraftThemeBackground
-													}
-												/>
-												<TextControl
-													__nextHasNoMarginBottom
-													label={ __(
-														'Foreground',
-														'autoblue'
-													) }
-													value={
-														draftThemeForeground
-													}
-													placeholder="#111111"
-													onChange={
-														setDraftThemeForeground
-													}
-												/>
-											</HStack>
-											<HStack spacing={ 3 } alignment="top">
-												<TextControl
-													__nextHasNoMarginBottom
-													label={ __(
-														'Accent',
-														'autoblue'
-													) }
-													value={ draftThemeAccent }
-													placeholder="#0073aa"
-													onChange={
-														setDraftThemeAccent
-													}
-												/>
-												<TextControl
-													__nextHasNoMarginBottom
-													label={ __(
-														'Accent foreground',
-														'autoblue'
-													) }
-													value={
-														draftThemeAccentFg
-													}
-													placeholder="#ffffff"
-													onChange={
-														setDraftThemeAccentFg
-													}
-												/>
-											</HStack>
+											<PaletteEdit
+												colors={ themePalette }
+												onChange={ handleThemeChange }
+												canOnlyChangeValues
+												paletteLabel={ __(
+													'Theme colors',
+													'autoblue'
+												) }
+												popoverProps={ {
+													offset: 8,
+													placement: 'bottom-start',
+												} }
+											/>
 											<HStack alignment="left">
 												<Button
 													variant="primary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -18,6 +18,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
+import { MediaUpload, MediaUploadCheck } from '@wordpress/media-utils';
 import NoAccountsPlaceholder from './../no-accounts-placeholder';
 import AccountList from './../account-list';
 import SettingToggle from './../setting-toggle';
@@ -46,6 +47,7 @@ const Settings = () => {
 
 	const savedName = publicationOverrides.name ?? '';
 	const savedDescription = publicationOverrides.description ?? '';
+	const savedIconId = publicationOverrides.icon_id ?? null;
 	const savedThemeBackground = publicationOverrides.theme_background ?? '';
 	const savedThemeForeground = publicationOverrides.theme_foreground ?? '';
 	const savedThemeAccent = publicationOverrides.theme_accent ?? '';
@@ -53,6 +55,10 @@ const Settings = () => {
 
 	const [ draftName, setDraftName ] = useState( savedName );
 	const [ draftDescription, setDraftDescription ] = useState( savedDescription );
+	const [ draftIconId, setDraftIconId ] = useState( savedIconId );
+	const [ draftIconUrl, setDraftIconUrl ] = useState(
+		standardSitePublication.iconOverrideUrl || ''
+	);
 	const [ draftThemeBackground, setDraftThemeBackground ] = useState( savedThemeBackground );
 	const [ draftThemeForeground, setDraftThemeForeground ] = useState( savedThemeForeground );
 	const [ draftThemeAccent, setDraftThemeAccent ] = useState( savedThemeAccent );
@@ -65,6 +71,9 @@ const Settings = () => {
 	useEffect( () => {
 		setDraftDescription( savedDescription );
 	}, [ savedDescription ] );
+	useEffect( () => {
+		setDraftIconId( savedIconId );
+	}, [ savedIconId ] );
 	useEffect( () => {
 		setDraftThemeBackground( savedThemeBackground );
 	}, [ savedThemeBackground ] );
@@ -81,6 +90,7 @@ const Settings = () => {
 	const isPublicationDirty =
 		draftName !== savedName ||
 		draftDescription !== savedDescription ||
+		( draftIconId || null ) !== ( savedIconId || null ) ||
 		draftThemeBackground !== savedThemeBackground ||
 		draftThemeForeground !== savedThemeForeground ||
 		draftThemeAccent !== savedThemeAccent ||
@@ -93,6 +103,9 @@ const Settings = () => {
 		}
 		if ( draftDescription.trim() !== '' ) {
 			next.description = draftDescription;
+		}
+		if ( draftIconId ) {
+			next.icon_id = Number( draftIconId );
 		}
 		if ( draftThemeBackground.trim() !== '' ) {
 			next.theme_background = draftThemeBackground;
@@ -108,6 +121,19 @@ const Settings = () => {
 		}
 		savePublicationOverrides( next );
 	};
+
+	const handleSelectIcon = ( media ) => {
+		setDraftIconId( media.id );
+		setDraftIconUrl( media.url || '' );
+	};
+
+	const handleRemoveIcon = () => {
+		setDraftIconId( null );
+		setDraftIconUrl( '' );
+	};
+
+	const currentIconUrl =
+		draftIconUrl || standardSitePublication.siteIconUrl || '';
 
 	return (
 		<>
@@ -258,6 +284,96 @@ const Settings = () => {
 												) }
 												onChange={ setDraftDescription }
 											/>
+											<BaseControl
+												__nextHasNoMarginBottom
+												label={ __(
+													'Publication icon',
+													'autoblue'
+												) }
+												help={
+													draftIconId
+														? __(
+																'Custom icon set. Remove to fall back to the WordPress site icon.',
+																'autoblue'
+														  )
+														: __(
+																'Falls back to the WordPress site icon. Should be at least 256×256.',
+																'autoblue'
+														  )
+												}
+												id="autoblue-publication-icon"
+											>
+												<HStack
+													spacing={ 3 }
+													alignment="left"
+												>
+													{ currentIconUrl ? (
+														<img
+															src={
+																currentIconUrl
+															}
+															alt=""
+															className={
+																styles.iconPreview
+															}
+														/>
+													) : (
+														<div
+															className={
+																styles.iconPlaceholder
+															}
+														/>
+													) }
+													<MediaUploadCheck>
+														<MediaUpload
+															onSelect={
+																handleSelectIcon
+															}
+															allowedTypes={ [
+																'image',
+															] }
+															value={
+																draftIconId ||
+																undefined
+															}
+															render={ ( {
+																open,
+															} ) => (
+																<Button
+																	variant="secondary"
+																	onClick={
+																		open
+																	}
+																>
+																	{ draftIconId
+																		? __(
+																				'Replace icon',
+																				'autoblue'
+																		  )
+																		: __(
+																				'Choose icon',
+																				'autoblue'
+																		  ) }
+																</Button>
+															) }
+														/>
+													</MediaUploadCheck>
+													{ draftIconId && (
+														<Button
+															variant="tertiary"
+															isDestructive
+															onClick={
+																handleRemoveIcon
+															}
+														>
+															{ __(
+																'Remove',
+																'autoblue'
+															) }
+														</Button>
+													) }
+												</HStack>
+											</BaseControl>
 											<TextControl
 												__nextHasNoMarginBottom
 												label={ __(

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -46,9 +46,17 @@ const Settings = () => {
 
 	const savedName = publicationOverrides.name ?? '';
 	const savedDescription = publicationOverrides.description ?? '';
+	const savedThemeBackground = publicationOverrides.theme_background ?? '';
+	const savedThemeForeground = publicationOverrides.theme_foreground ?? '';
+	const savedThemeAccent = publicationOverrides.theme_accent ?? '';
+	const savedThemeAccentFg = publicationOverrides.theme_accent_foreground ?? '';
 
 	const [ draftName, setDraftName ] = useState( savedName );
 	const [ draftDescription, setDraftDescription ] = useState( savedDescription );
+	const [ draftThemeBackground, setDraftThemeBackground ] = useState( savedThemeBackground );
+	const [ draftThemeForeground, setDraftThemeForeground ] = useState( savedThemeForeground );
+	const [ draftThemeAccent, setDraftThemeAccent ] = useState( savedThemeAccent );
+	const [ draftThemeAccentFg, setDraftThemeAccentFg ] = useState( savedThemeAccentFg );
 
 	// Re-sync drafts when the saved overrides change (initial load + after our own save).
 	useEffect( () => {
@@ -57,9 +65,26 @@ const Settings = () => {
 	useEffect( () => {
 		setDraftDescription( savedDescription );
 	}, [ savedDescription ] );
+	useEffect( () => {
+		setDraftThemeBackground( savedThemeBackground );
+	}, [ savedThemeBackground ] );
+	useEffect( () => {
+		setDraftThemeForeground( savedThemeForeground );
+	}, [ savedThemeForeground ] );
+	useEffect( () => {
+		setDraftThemeAccent( savedThemeAccent );
+	}, [ savedThemeAccent ] );
+	useEffect( () => {
+		setDraftThemeAccentFg( savedThemeAccentFg );
+	}, [ savedThemeAccentFg ] );
 
 	const isPublicationDirty =
-		draftName !== savedName || draftDescription !== savedDescription;
+		draftName !== savedName ||
+		draftDescription !== savedDescription ||
+		draftThemeBackground !== savedThemeBackground ||
+		draftThemeForeground !== savedThemeForeground ||
+		draftThemeAccent !== savedThemeAccent ||
+		draftThemeAccentFg !== savedThemeAccentFg;
 
 	const handleUpdatePublication = () => {
 		const next = {};
@@ -68,6 +93,18 @@ const Settings = () => {
 		}
 		if ( draftDescription.trim() !== '' ) {
 			next.description = draftDescription;
+		}
+		if ( draftThemeBackground.trim() !== '' ) {
+			next.theme_background = draftThemeBackground;
+		}
+		if ( draftThemeForeground.trim() !== '' ) {
+			next.theme_foreground = draftThemeForeground;
+		}
+		if ( draftThemeAccent.trim() !== '' ) {
+			next.theme_accent = draftThemeAccent;
+		}
+		if ( draftThemeAccentFg.trim() !== '' ) {
+			next.theme_accent_foreground = draftThemeAccentFg;
 		}
 		savePublicationOverrides( next );
 	};
@@ -246,6 +283,70 @@ const Settings = () => {
 													readOnly
 												/>
 											) }
+											<Text variant="muted">
+												{ __(
+													'Theme colors are used by standard.site readers to style your publication. Leave blank to omit.',
+													'autoblue'
+												) }
+											</Text>
+											<HStack spacing={ 3 } alignment="top">
+												<TextControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Background',
+														'autoblue'
+													) }
+													value={
+														draftThemeBackground
+													}
+													placeholder="#ffffff"
+													onChange={
+														setDraftThemeBackground
+													}
+												/>
+												<TextControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Foreground',
+														'autoblue'
+													) }
+													value={
+														draftThemeForeground
+													}
+													placeholder="#111111"
+													onChange={
+														setDraftThemeForeground
+													}
+												/>
+											</HStack>
+											<HStack spacing={ 3 } alignment="top">
+												<TextControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Accent',
+														'autoblue'
+													) }
+													value={ draftThemeAccent }
+													placeholder="#0073aa"
+													onChange={
+														setDraftThemeAccent
+													}
+												/>
+												<TextControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Accent foreground',
+														'autoblue'
+													) }
+													value={
+														draftThemeAccentFg
+													}
+													placeholder="#ffffff"
+													onChange={
+														setDraftThemeAccentFg
+													}
+												/>
+											</HStack>
 											<HStack alignment="left">
 												<Button
 													variant="primary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -161,22 +161,22 @@ const Settings = () => {
 		{
 			slug: 'background',
 			name: __( 'Background', 'autoblue' ),
-			color: draftThemeBackground || '#ffffff',
+			color: draftThemeBackground,
 		},
 		{
 			slug: 'foreground',
 			name: __( 'Foreground', 'autoblue' ),
-			color: draftThemeForeground || '#111111',
+			color: draftThemeForeground,
 		},
 		{
 			slug: 'accent',
 			name: __( 'Accent', 'autoblue' ),
-			color: draftThemeAccent || '#0073aa',
+			color: draftThemeAccent,
 		},
 		{
 			slug: 'accent_foreground',
 			name: __( 'Accent foreground', 'autoblue' ),
-			color: draftThemeAccentFg || '#ffffff',
+			color: draftThemeAccentFg,
 		},
 	];
 

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -376,78 +376,6 @@ const Settings = () => {
 												) }
 												onChange={ setDraftDescription }
 											/>
-											<BaseControl
-												__nextHasNoMarginBottom
-												label={ __(
-													'Publication icon',
-													'autoblue'
-												) }
-												help={
-													draftIconId
-														? __(
-																'Custom icon set. Remove to fall back to the WordPress site icon.',
-																'autoblue'
-														  )
-														: __(
-																'Falls back to the WordPress site icon. Should be at least 256×256.',
-																'autoblue'
-														  )
-												}
-												id="autoblue-publication-icon"
-											>
-												<HStack
-													spacing={ 3 }
-													alignment="left"
-												>
-													{ currentIconUrl ? (
-														<img
-															src={
-																currentIconUrl
-															}
-															alt=""
-															className={
-																styles.iconPreview
-															}
-														/>
-													) : (
-														<div
-															className={
-																styles.iconPlaceholder
-															}
-														/>
-													) }
-													<Button
-														variant="secondary"
-														onClick={
-															openIconPicker
-														}
-													>
-														{ draftIconId
-															? __(
-																	'Replace icon',
-																	'autoblue'
-															  )
-															: __(
-																	'Choose icon',
-																	'autoblue'
-															  ) }
-													</Button>
-													{ draftIconId && (
-														<Button
-															variant="tertiary"
-															isDestructive
-															onClick={
-																handleRemoveIcon
-															}
-														>
-															{ __(
-																'Remove',
-																'autoblue'
-															) }
-														</Button>
-													) }
-												</HStack>
-											</BaseControl>
 											<TextControl
 												__nextHasNoMarginBottom
 												label={ __(
@@ -473,55 +401,129 @@ const Settings = () => {
 													readOnly
 												/>
 											) }
-											<BaseControl
-												__nextHasNoMarginBottom
-												label={ __(
-													'Publication colors',
-													'autoblue'
-												) }
-												id="autoblue-publication-colors"
-											>
-												<VStack spacing={ 3 }>
-													<ToggleControl
-														__nextHasNoMarginBottom
-														label={ __(
-															'Customize publication colors',
-															'autoblue'
-														) }
-														checked={
-															draftHasTheme
-														}
-														onChange={
-															handleToggleTheme
-														}
-													/>
-													{ draftHasTheme && (
-														<>
-															<PaletteEdit
-																colors={
-																	themePalette
+											<div className={ styles.split }>
+												<BaseControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Publication icon',
+														'autoblue'
+													) }
+													help={
+														draftIconId
+															? __(
+																	'Custom icon set. Remove to fall back to the WordPress site icon.',
+																	'autoblue'
+															  )
+															: __(
+																	'Falls back to the WordPress site icon. Should be at least 256×256.',
+																	'autoblue'
+															  )
+													}
+													id="autoblue-publication-icon"
+												>
+													<HStack
+														spacing={ 3 }
+														alignment="left"
+													>
+														{ currentIconUrl ? (
+															<img
+																src={
+																	currentIconUrl
 																}
-																onChange={
-																	handleThemeChange
+																alt=""
+																className={
+																	styles.iconPreview
 																}
-																canOnlyChangeValues
-																paletteLabel=""
-																popoverProps={ {
-																	offset: 8,
-																	placement:
-																		'bottom-start',
-																} }
 															/>
-															<Text variant="muted">
+														) : (
+															<div
+																className={
+																	styles.iconPlaceholder
+																}
+															/>
+														) }
+														<Button
+															variant="secondary"
+															onClick={
+																openIconPicker
+															}
+														>
+															{ draftIconId
+																? __(
+																		'Replace icon',
+																		'autoblue'
+																  )
+																: __(
+																		'Choose icon',
+																		'autoblue'
+																  ) }
+														</Button>
+														{ draftIconId && (
+															<Button
+																variant="tertiary"
+																isDestructive
+																onClick={
+																	handleRemoveIcon
+																}
+															>
 																{ __(
-																	'Theme colors are used by standard.site readers to style your publication.',
+																	'Remove',
 																	'autoblue'
 																) }
-															</Text>
-														</>
+															</Button>
+														) }
+													</HStack>
+												</BaseControl>
+												<BaseControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Publication colors',
+														'autoblue'
 													) }
-												</VStack>
-											</BaseControl>
+													id="autoblue-publication-colors"
+												>
+													<VStack spacing={ 3 }>
+														<ToggleControl
+															__nextHasNoMarginBottom
+															label={ __(
+																'Customize publication colors',
+																'autoblue'
+															) }
+															checked={
+																draftHasTheme
+															}
+															onChange={
+																handleToggleTheme
+															}
+														/>
+														{ draftHasTheme && (
+															<>
+																<PaletteEdit
+																	colors={
+																		themePalette
+																	}
+																	onChange={
+																		handleThemeChange
+																	}
+																	canOnlyChangeValues
+																	paletteLabel=""
+																	popoverProps={ {
+																		offset: 8,
+																		placement:
+																			'bottom-start',
+																	} }
+																/>
+																<Text variant="muted">
+																	{ __(
+																		'Theme colors are used by standard.site readers to style your publication.',
+																		'autoblue'
+																	) }
+																</Text>
+															</>
+														) }
+													</VStack>
+												</BaseControl>
+											</div>
 											<HStack alignment="left">
 												<Button
 													variant="primary"

--- a/src/js/components/settings/index.js
+++ b/src/js/components/settings/index.js
@@ -161,22 +161,22 @@ const Settings = () => {
 		{
 			slug: 'background',
 			name: __( 'Background', 'autoblue' ),
-			color: draftThemeBackground,
+			color: draftThemeBackground || 'transparent',
 		},
 		{
 			slug: 'foreground',
 			name: __( 'Foreground', 'autoblue' ),
-			color: draftThemeForeground,
+			color: draftThemeForeground || 'transparent',
 		},
 		{
 			slug: 'accent',
 			name: __( 'Accent', 'autoblue' ),
-			color: draftThemeAccent,
+			color: draftThemeAccent || 'transparent',
 		},
 		{
 			slug: 'accent_foreground',
 			name: __( 'Accent foreground', 'autoblue' ),
-			color: draftThemeAccentFg,
+			color: draftThemeAccentFg || 'transparent',
 		},
 	];
 
@@ -191,9 +191,10 @@ const Settings = () => {
 		if ( ! Array.isArray( nextPalette ) ) return;
 		nextPalette.forEach( ( entry ) => {
 			const setter = themeSetters[ entry.slug ];
-			if ( setter ) {
-				setter( entry.color || '' );
-			}
+			if ( ! setter ) return;
+			const raw = entry.color || '';
+			// Transparent (our sentinel for "no override") maps back to empty.
+			setter( raw === 'transparent' ? '' : raw );
 		} );
 	};
 

--- a/src/js/components/settings/styles.module.scss
+++ b/src/js/components/settings/styles.module.scss
@@ -31,3 +31,11 @@
 		min-width: 0;
 	}
 }
+
+.palette {
+	// Hide PaletteEdit's built-in header row (empty <h2> + 3-dot menu).
+	// canOnlyChangeValues makes the menu inert and the heading is empty.
+	> div > div:first-child {
+		display: none;
+	}
+}

--- a/src/js/components/settings/styles.module.scss
+++ b/src/js/components/settings/styles.module.scss
@@ -19,3 +19,15 @@
 .iconPlaceholder {
 	border: 1px dashed rgba(0, 0, 0, 0.15);
 }
+
+.split {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	align-items: flex-start;
+
+	> * {
+		flex: 1 1 240px;
+		min-width: 0;
+	}
+}

--- a/src/js/components/settings/styles.module.scss
+++ b/src/js/components/settings/styles.module.scss
@@ -5,3 +5,17 @@
 		padding: 10px;
 	}
 }
+
+.iconPreview,
+.iconPlaceholder {
+	width: 64px;
+	height: 64px;
+	border-radius: 8px;
+	object-fit: cover;
+	background: #f1f1f1;
+	flex-shrink: 0;
+}
+
+.iconPlaceholder {
+	border: 1px dashed rgba(0, 0, 0, 0.15);
+}

--- a/src/js/components/share-panel/index.js
+++ b/src/js/components/share-panel/index.js
@@ -13,23 +13,30 @@ import AccountInfo from './../account-info';
 import PublishedPostPanel from './../published-post-panel';
 import useConnectAccountModal from './../connect-account-modal';
 import useAccounts from './../../hooks/use-accounts';
+import useSettings from './../../hooks/use-settings';
 import styles from './styles.module.scss';
 
 const SharePanel = () => {
 	const { accounts } = useAccounts();
 	const { renderModal, openModal } = useConnectAccountModal();
 	const { editPost } = useDispatch( 'core/editor' );
+	const { isStandardSiteEnabled, isRootInstall } = useSettings();
 
-	const { postStatus, isEnabled, customMessage } = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
+	const { postStatus, isEnabled, customMessage, publishDocument } = useSelect(
+		( select ) => {
+			const { getEditedPostAttribute } = select( 'core/editor' );
 
-		return {
-			postStatus: getEditedPostAttribute( 'status' ),
-			isEnabled: getEditedPostAttribute( 'meta' )?.autoblue_enabled,
-			customMessage:
-				getEditedPostAttribute( 'meta' )?.autoblue_custom_message,
-		};
-	}, [] );
+			return {
+				postStatus: getEditedPostAttribute( 'status' ),
+				isEnabled: getEditedPostAttribute( 'meta' )?.autoblue_enabled,
+				customMessage:
+					getEditedPostAttribute( 'meta' )?.autoblue_custom_message,
+				publishDocument:
+					getEditedPostAttribute( 'meta' )?.autoblue_publish_document,
+			};
+		},
+		[]
+	);
 
 	if ( postStatus === 'publish' ) {
 		return <PublishedPostPanel />;
@@ -58,8 +65,32 @@ const SharePanel = () => {
 		} );
 	};
 
+	const setPublishDocument = ( value ) => {
+		editPost( {
+			meta: { autoblue_publish_document: value },
+		} );
+	};
+
 	const hasBrokenConnection = accounts.some( ( a ) => a.needs_reauth );
 	const effectiveIsEnabled = isEnabled && ! hasBrokenConnection;
+	const standardSiteDisabledReason = ! isRootInstall
+		? __(
+				'standard.site is not available on subdirectory installs.',
+				'autoblue'
+		  )
+		: ! isStandardSiteEnabled
+		? __(
+				'Enable standard.site publishing in Autoblue settings.',
+				'autoblue'
+		  )
+		: hasBrokenConnection
+		? __(
+				'Reconnect your Bluesky account to publish documents.',
+				'autoblue'
+		  )
+		: null;
+	const standardSiteToggleEnabled =
+		isStandardSiteEnabled && isRootInstall && ! hasBrokenConnection;
 
 	return (
 		<VStack spacing={ 3 }>
@@ -86,6 +117,25 @@ const SharePanel = () => {
 				onChange={ setIsEnabled }
 				disabled={ hasBrokenConnection }
 			/>
+			{ effectiveIsEnabled && (
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __(
+						'Also publish as a standard.site document',
+						'autoblue'
+					) }
+					help={
+						standardSiteDisabledReason ||
+						__(
+							'Stores the full article on your AT Protocol PDS for discovery by other readers.',
+							'autoblue'
+						)
+					}
+					checked={ standardSiteToggleEnabled && !! publishDocument }
+					onChange={ setPublishDocument }
+					disabled={ ! standardSiteToggleEnabled }
+				/>
+			) }
 			{ effectiveIsEnabled && (
 				<>
 					<TextareaControl

--- a/src/js/components/share-panel/index.js
+++ b/src/js/components/share-panel/index.js
@@ -121,7 +121,7 @@ const SharePanel = () => {
 				<ToggleControl
 					__nextHasNoMarginBottom
 					label={ __(
-						'Also publish as a standard.site document',
+						'Publish as a standard.site document',
 						'autoblue'
 					) }
 					help={

--- a/src/js/hooks/use-settings.js
+++ b/src/js/hooks/use-settings.js
@@ -14,6 +14,16 @@ const useSettings = () => {
 		'site',
 		'autoblue_enabled_post_types'
 	);
+	const [ standardSiteEnabled, setStandardSiteEnabledFn ] = useEntityProp(
+		'root',
+		'site',
+		'autoblue_publish_documents_enabled'
+	);
+	const [ publicationOverrides, setPublicationOverridesFn ] = useEntityProp(
+		'root',
+		'site',
+		'autoblue_publication_overrides'
+	);
 	const { saveEditedEntityRecord } = useDispatch( 'core' );
 	const { createSuccessNotice, removeNotice } = useDispatch( noticesStore );
 
@@ -64,6 +74,40 @@ const useSettings = () => {
 		} catch ( error ) {}
 	};
 
+	const setIsStandardSiteEnabled = async ( value ) => {
+		if ( isSaving ) {
+			return;
+		}
+		try {
+			setStandardSiteEnabledFn( value );
+			await saveEditedEntityRecord( 'root', 'site' );
+		} catch ( error ) {}
+	};
+
+	const resolvedOverrides =
+		publicationOverrides && typeof publicationOverrides === 'object'
+			? publicationOverrides
+			: {};
+
+	const setPublicationOverride = async ( key, value ) => {
+		if ( isSaving ) {
+			return;
+		}
+		const next = { ...resolvedOverrides };
+		if ( value === null || value === '' ) {
+			delete next[ key ];
+		} else {
+			next[ key ] = value;
+		}
+		try {
+			setPublicationOverridesFn( next );
+			await saveEditedEntityRecord( 'root', 'site' );
+		} catch ( error ) {}
+	};
+
+	const standardSiteInitial =
+		autoblue?.initialState?.settings?.standardSite || {};
+
 	return {
 		isEnabled:
 			isEnabled !== undefined && isEnabled !== null
@@ -75,6 +119,13 @@ const useSettings = () => {
 		availablePostTypes:
 			autoblue?.initialState?.settings?.availablePostTypes || [],
 		togglePostType,
+		isStandardSiteEnabled: !! standardSiteEnabled,
+		isLoadingStandardSite: standardSiteEnabled === undefined,
+		setIsStandardSiteEnabled,
+		publicationOverrides: resolvedOverrides,
+		setPublicationOverride,
+		standardSitePublication: standardSiteInitial.publication || {},
+		isRootInstall: standardSiteInitial.isRootInstall !== false,
 		isSaving,
 	};
 };

--- a/src/js/hooks/use-settings.js
+++ b/src/js/hooks/use-settings.js
@@ -89,19 +89,21 @@ const useSettings = () => {
 			? publicationOverrides
 			: {};
 
-	const setPublicationOverride = async ( key, value ) => {
+	const savePublicationOverrides = async ( next ) => {
 		if ( isSaving ) {
 			return;
-		}
-		const next = { ...resolvedOverrides };
-		if ( value === null || value === '' ) {
-			delete next[ key ];
-		} else {
-			next[ key ] = value;
 		}
 		try {
 			setPublicationOverridesFn( next );
 			await saveEditedEntityRecord( 'root', 'site' );
+
+			const notice = await createSuccessNotice(
+				__( 'Publication updated.', 'autoblue' ),
+				{ type: 'snackbar' }
+			);
+			setTimeout( () => {
+				removeNotice( notice.notice.id );
+			}, 2000 );
 		} catch ( error ) {}
 	};
 
@@ -123,7 +125,7 @@ const useSettings = () => {
 		isLoadingStandardSite: standardSiteEnabled === undefined,
 		setIsStandardSiteEnabled,
 		publicationOverrides: resolvedOverrides,
-		setPublicationOverride,
+		savePublicationOverrides,
 		standardSitePublication: standardSiteInitial.publication || {},
 		isRootInstall: standardSiteInitial.isRootInstall !== false,
 		isSaving,

--- a/tests/wpunit/BlueskyTest.php
+++ b/tests/wpunit/BlueskyTest.php
@@ -66,6 +66,77 @@ class BlueskyTest extends WPTestCase {
 		$this->bluesky->share_to_bluesky( $post_id );
 	}
 
+	public function test_standard_site_share_uses_atomic_apply_writes_and_document_strong_ref() {
+		$post_id = $this->create_test_post( self::ORIGINAL_MESSAGE );
+		$this->enable_standard_site_for_post( $post_id );
+
+		$this->log_mock->shouldReceive( 'success' );
+		$this->api_mock->shouldReceive( 'apply_writes' )
+			->once()
+			->withArgs(
+				static function ( $writes ) {
+					return count( $writes ) === 2
+						&& $writes[0]['collection'] === 'app.bsky.feed.post'
+						&& $writes[1]['collection'] === 'site.standard.document'
+						&& ! isset( $writes[0]['value']['embed']['external']['associatedRefs'] )
+						&& ! isset( $writes[1]['value']['bskyPostRef'] );
+				}
+			)
+			->andReturn(
+				[
+					'results' => [
+						[
+							'uri' => 'at://mock-did/app.bsky.feed.post/bsky123',
+							'cid' => 'bsky-cid',
+						],
+						[
+							'uri' => 'at://mock-did/site.standard.document/doc123',
+							'cid' => 'doc-cid',
+						],
+					],
+				]
+			);
+		$this->api_mock->shouldReceive( 'put_record' )
+			->once()
+			->withArgs(
+				static function ( $body ) {
+					return $body['collection'] === 'site.standard.document'
+						&& $body['record']['bskyPostRef']['uri'] === 'at://mock-did/app.bsky.feed.post/bsky123'
+						&& $body['record']['bskyPostRef']['cid'] === 'bsky-cid';
+				}
+			)
+			->andReturn(
+				[
+					'uri' => 'at://mock-did/site.standard.document/doc123',
+					'cid' => 'doc-cid-with-bsky-ref',
+				]
+			);
+
+		$share = $this->bluesky->share_to_bluesky( $post_id );
+		$doc   = get_post_meta( $post_id, 'autoblue_document', true );
+
+		$this->assertSame( 'at://mock-did/app.bsky.feed.post/bsky123', $share['uri'] );
+		$this->assertSame( 'at://mock-did/site.standard.document/doc123', $doc['uri'] );
+		$this->assertSame( 'doc-cid-with-bsky-ref', $doc['cid'] );
+	}
+
+	public function test_standard_site_apply_writes_failure_does_not_store_document_uri() {
+		$post_id = $this->create_test_post( self::ORIGINAL_MESSAGE );
+		$this->enable_standard_site_for_post( $post_id );
+
+		$this->log_mock->shouldReceive( 'error' )->once();
+		$this->api_mock->shouldReceive( 'apply_writes' )
+			->once()
+			->andReturn( new \WP_Error( 'mock_apply_writes_failed', 'No records were written.' ) );
+		$this->api_mock->shouldReceive( 'put_record' )->never();
+
+		$this->assertFalse( $this->bluesky->share_to_bluesky( $post_id ) );
+
+		$doc = get_post_meta( $post_id, 'autoblue_document', true );
+		$this->assertIsArray( $doc );
+		$this->assertArrayNotHasKey( 'uri', $doc );
+	}
+
 	private function create_test_post( string $original_message ): int {
 		return wp_insert_post(
 			[
@@ -93,8 +164,26 @@ class BlueskyTest extends WPTestCase {
 			);
 	}
 
+	private function enable_standard_site_for_post( int $post_id ): void {
+		update_option( 'autoblue_publish_documents_enabled', true );
+		update_option( 'autoblue_connections', [ self::MOCK_CONNECTION ] );
+		update_option(
+			'autoblue_publication_record',
+			[
+				'did'  => self::MOCK_CONNECTION['did'],
+				'uri'  => 'at://mock-did/site.standard.publication/pub123',
+				'cid'  => 'pub-cid',
+				'rkey' => 'pub123',
+			]
+		);
+		update_post_meta( $post_id, 'autoblue_publish_document', true );
+	}
+
 	protected function tearDown(): void {
 		remove_all_filters( 'autoblue/share_message' );
+		delete_option( 'autoblue_publish_documents_enabled' );
+		delete_option( 'autoblue_connections' );
+		delete_option( 'autoblue_publication_record' );
 		Mockery::close();
 		parent::tearDown();
 	}

--- a/tests/wpunit/Standard/DocumentTest.php
+++ b/tests/wpunit/Standard/DocumentTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Standard;
+
+use Autoblue\Standard\Document;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+class DocumentTest extends WPTestCase {
+	private const PUBLICATION_URI = 'at://did:plc:testuser/site.standard.publication/pub123';
+	private const BSKY_REF        = [
+		'uri' => 'at://did:plc:testuser/app.bsky.feed.post/post123',
+		'cid' => 'bafyreitestcid',
+	];
+
+	public function test_build_record_has_required_fields(): void {
+		$post_id = $this->insert_post( 'Article Title', 'Body content here.' );
+		$post    = get_post( $post_id );
+
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, null );
+
+		$this->assertSame( 'site.standard.document', $record['$type'] );
+		$this->assertSame( self::PUBLICATION_URI, $record['site'] );
+		$this->assertSame( 'Article Title', $record['title'] );
+		$this->assertArrayHasKey( 'publishedAt', $record );
+		$this->assertNotEmpty( $record['publishedAt'] );
+	}
+
+	public function test_build_record_includes_bsky_post_ref(): void {
+		$post_id = $this->insert_post( 'Article Title', 'Body content here.' );
+		$post    = get_post( $post_id );
+
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, null );
+
+		$this->assertSame( self::BSKY_REF['uri'], $record['bskyPostRef']['uri'] );
+		$this->assertSame( self::BSKY_REF['cid'], $record['bskyPostRef']['cid'] );
+	}
+
+	public function test_build_record_truncates_tags_to_8(): void {
+		$post_id = $this->insert_post( 'Article', 'Body.' );
+
+		$slugs = [];
+		for ( $i = 1; $i <= 12; $i++ ) {
+			$slugs[] = "tag-{$i}";
+		}
+		wp_set_post_tags( $post_id, $slugs );
+
+		$post   = get_post( $post_id );
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, null );
+
+		$this->assertCount( 8, $record['tags'] );
+	}
+
+	public function test_build_record_omits_cover_image_when_missing(): void {
+		$post_id = $this->insert_post( 'Article', 'Body.' );
+		$post    = get_post( $post_id );
+
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, null );
+
+		$this->assertArrayNotHasKey( 'coverImage', $record );
+	}
+
+	public function test_build_record_includes_cover_image_when_provided(): void {
+		$post_id = $this->insert_post( 'Article', 'Body.' );
+		$post    = get_post( $post_id );
+
+		$blob   = [
+			'$type'    => 'blob',
+			'ref'      => [ '$link' => 'bafyreiblob' ],
+			'mimeType' => 'image/jpeg',
+			'size'     => 1024,
+		];
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, $blob );
+
+		$this->assertSame( $blob, $record['coverImage'] );
+	}
+
+	public function test_build_record_includes_text_content(): void {
+		$post_id = $this->insert_post( 'Article', '<p>Hello <strong>world</strong>.</p>' );
+		$post    = get_post( $post_id );
+
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, null );
+
+		$this->assertArrayHasKey( 'textContent', $record );
+		$this->assertStringContainsString( 'Hello world.', $record['textContent'] );
+		$this->assertStringNotContainsString( '<strong>', $record['textContent'] );
+	}
+
+	public function test_build_record_includes_path(): void {
+		$post_id = $this->insert_post( 'Article', 'Body.' );
+		$post    = get_post( $post_id );
+
+		$record = ( new Document() )->build_record( $post, self::PUBLICATION_URI, self::BSKY_REF, null );
+
+		$this->assertArrayHasKey( 'path', $record );
+		$this->assertStringStartsWith( '/', $record['path'] );
+	}
+
+	private function insert_post( string $title, string $content ): int {
+		return wp_insert_post(
+			[
+				'post_title'   => $title,
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			]
+		);
+	}
+}

--- a/tests/wpunit/Standard/PublicationTest.php
+++ b/tests/wpunit/Standard/PublicationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Standard;
+
+use Autoblue\Standard\Publication;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+class PublicationTest extends WPTestCase {
+	private const CONNECTION = [
+		'did'         => 'did:plc:testuser',
+		'access_jwt'  => 'test-access',
+		'refresh_jwt' => 'test-refresh',
+	];
+
+	public function test_build_record_uses_wp_defaults_when_no_overrides(): void {
+		update_option( 'blogname', 'My Blog' );
+		update_option( 'blogdescription', 'Just my thoughts' );
+		delete_option( 'autoblue_publication_overrides' );
+
+		$record = ( new Publication() )->build_record( self::CONNECTION );
+
+		$this->assertSame( 'site.standard.publication', $record['$type'] );
+		$this->assertSame( 'My Blog', $record['name'] );
+		$this->assertSame( 'Just my thoughts', $record['description'] );
+		$this->assertSame( untrailingslashit( home_url( '/' ) ), $record['url'] );
+	}
+
+	public function test_build_record_uses_overrides_when_set(): void {
+		update_option( 'blogname', 'My Blog' );
+		update_option( 'blogdescription', 'Just my thoughts' );
+		update_option(
+			'autoblue_publication_overrides',
+			[
+				'name'        => 'Custom Publication',
+				'description' => 'Custom description',
+			]
+		);
+
+		$record = ( new Publication() )->build_record( self::CONNECTION );
+
+		$this->assertSame( 'Custom Publication', $record['name'] );
+		$this->assertSame( 'Custom description', $record['description'] );
+	}
+
+	public function test_build_record_falls_back_per_field(): void {
+		update_option( 'blogname', 'My Blog' );
+		update_option( 'blogdescription', 'Just my thoughts' );
+		update_option(
+			'autoblue_publication_overrides',
+			[
+				'name' => 'Custom Publication',
+				// description not overridden
+			]
+		);
+
+		$record = ( new Publication() )->build_record( self::CONNECTION );
+
+		$this->assertSame( 'Custom Publication', $record['name'] );
+		$this->assertSame( 'Just my thoughts', $record['description'] );
+	}
+
+	public function test_build_record_treats_empty_string_override_as_unset(): void {
+		update_option( 'blogname', 'My Blog' );
+		update_option(
+			'autoblue_publication_overrides',
+			[
+				'name' => '   ',
+			]
+		);
+
+		$record = ( new Publication() )->build_record( self::CONNECTION );
+
+		$this->assertSame( 'My Blog', $record['name'] );
+	}
+
+	public function test_build_record_omits_description_when_blank(): void {
+		update_option( 'blogname', 'My Blog' );
+		update_option( 'blogdescription', '' );
+		delete_option( 'autoblue_publication_overrides' );
+
+		$record = ( new Publication() )->build_record( self::CONNECTION );
+
+		$this->assertArrayNotHasKey( 'description', $record );
+	}
+
+	public function test_get_uri_returns_stored_uri(): void {
+		update_option(
+			'autoblue_publication_record',
+			[
+				'did' => self::CONNECTION['did'],
+				'uri' => 'at://did:plc:testuser/site.standard.publication/abc123',
+			]
+		);
+
+		$this->assertSame(
+			'at://did:plc:testuser/site.standard.publication/abc123',
+			( new Publication() )->get_uri()
+		);
+	}
+
+	public function test_get_uri_returns_null_when_unset(): void {
+		delete_option( 'autoblue_publication_record' );
+
+		$this->assertNull( ( new Publication() )->get_uri() );
+	}
+
+	public function test_clear_removes_stored_record(): void {
+		update_option(
+			'autoblue_publication_record',
+			[
+				'did' => self::CONNECTION['did'],
+				'uri' => 'at://did:plc:testuser/site.standard.publication/abc123',
+			]
+		);
+
+		( new Publication() )->clear();
+
+		$this->assertSame( [], get_option( 'autoblue_publication_record', [] ) );
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'autoblue_publication_overrides' );
+		delete_option( 'autoblue_publication_record' );
+		parent::tearDown();
+	}
+}

--- a/tests/wpunit/Standard/PublicationTest.php
+++ b/tests/wpunit/Standard/PublicationTest.php
@@ -49,7 +49,7 @@ class PublicationTest extends WPTestCase {
 			'autoblue_publication_overrides',
 			[
 				'name' => 'Custom Publication',
-				// description not overridden
+					// Description not overridden.
 			]
 		);
 

--- a/tests/wpunit/Standard/VerificationTest.php
+++ b/tests/wpunit/Standard/VerificationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Standard;
+
+use Autoblue\Standard\Verification;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+class VerificationTest extends WPTestCase {
+	public function test_inject_document_link_renders_on_singular_with_document(): void {
+		$post_id = wp_insert_post(
+			[
+				'post_title'   => 'Article',
+				'post_content' => 'Body',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			]
+		);
+		update_post_meta(
+			$post_id,
+			Verification::DOCUMENT_META,
+			[
+				'uri'  => 'at://did:plc:testuser/site.standard.document/doc123',
+				'cid'  => 'bafyreitest',
+				'rkey' => 'doc123',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		( new Verification() )->inject_document_link();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'rel="site.standard.document"', $output );
+		$this->assertStringContainsString( 'at://did:plc:testuser/site.standard.document/doc123', $output );
+	}
+
+	public function test_inject_document_link_skipped_on_singular_without_document(): void {
+		$post_id = wp_insert_post(
+			[
+				'post_title'   => 'Article',
+				'post_content' => 'Body',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		( new Verification() )->inject_document_link();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	public function test_inject_document_link_skipped_when_not_singular(): void {
+		$this->go_to( home_url( '/' ) );
+
+		ob_start();
+		( new Verification() )->inject_document_link();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+}

--- a/tests/wpunit/UtilsTest.php
+++ b/tests/wpunit/UtilsTest.php
@@ -25,8 +25,41 @@ class UtilsTest extends WPTestCase {
 		$this->assertSame( [ 'post' ], Utils::get_enabled_post_types() );
 	}
 
+	public function test_is_root_install_true_for_root(): void {
+		// Default test install is at root.
+		$this->assertTrue( Utils::is_root_install() );
+	}
+
+	public function test_is_standard_site_enabled_requires_global_toggle(): void {
+		update_option(
+			'autoblue_connections',
+			[
+				[
+					'did'         => 'did:plc:abc',
+					'access_jwt'  => 'a',
+					'refresh_jwt' => 'r',
+				],
+			]
+		);
+
+		delete_option( 'autoblue_publish_documents_enabled' );
+		$this->assertFalse( Utils::is_standard_site_enabled() );
+
+		update_option( 'autoblue_publish_documents_enabled', true );
+		$this->assertTrue( Utils::is_standard_site_enabled() );
+	}
+
+	public function test_is_standard_site_enabled_requires_a_connection(): void {
+		update_option( 'autoblue_publish_documents_enabled', true );
+		update_option( 'autoblue_connections', [] );
+
+		$this->assertFalse( Utils::is_standard_site_enabled() );
+	}
+
 	protected function tearDown(): void {
 		delete_option( 'autoblue_enabled_post_types' );
+		delete_option( 'autoblue_publish_documents_enabled' );
+		delete_option( 'autoblue_connections' );
 		parent::tearDown();
 	}
 }


### PR DESCRIPTION
> **Stacked on #46** (`feat/cpt-support`). Merge that one first; this PR's base is set to its branch so the diff stays focused on the standard.site work.

## Summary

[standard.site](https://standard.site) is a set of AT Protocol lexicons (`site.standard.*`) for long-form publishing — your full article lives as a typed record on your PDS where any AT-aware reader/aggregator can discover it. Bluesky stays the social engagement layer; standard.site is the content layer.

This PR adds the publishing half. When Autoblue shares a post to Bluesky, it now also writes a `site.standard.document` for the full article (with `bskyPostRef` back to the Bluesky post) and ensures a `site.standard.publication` exists for the site itself. Verification endpoints are served so AT clients can confirm the records belong to this domain.

The work intentionally stays narrow — no OAuth (app-password sessions already authorize writes to any collection), no subscriptions/recommends/threading/edit syncing/reaction sync. The plan file under `/Users/danielpost/.claude/plans/` documents the design decisions and explicit non-goals.

## Backend

- **`Utils::is_root_install()`** / **`is_standard_site_enabled()`** — guard helpers.
- **`Admin`** — registers `autoblue_publish_documents_enabled` (boolean) and `autoblue_publication_overrides` (object) settings.
- **`Meta`** — registers `autoblue_publish_document` per-post meta, looped over enabled post types (the pattern from #46).
- **`Bluesky\API::put_record`** — for in-place publication updates via `com.atproto.repo.putRecord`.
- **`Standard\Publication`** — build, create, sync, and cache the publication record on the PDS. Reactive hooks update on `blogname` / `blogdescription` / `site_icon` / override changes; fingerprint short-circuits no-op updates.
- **`Standard\Document`** — build and write document records per shared post (`title`, `path`, `description`, `textContent`, `tags`, `coverImage`, `bskyPostRef`). Reuses the blob ref from the Bluesky share for `coverImage` to avoid a duplicate upload.
- **`Standard\Verification`** — serves `/.well-known/site.standard.publication` as plain-text AT-URI, injects `<link rel="site.standard.document">` into singular post heads.
- **`Bluesky::share_to_bluesky`** — after a successful bsky post, hands off to `Document::publish` when the feature is on for that post. Document failures are logged but do not roll back the bsky post.
- **Subdir installs** fully disable the feature (no way to serve `/.well-known/` at the domain root).

## Frontend

- **Settings page** — new "standard.site" section with a global toggle, per-field override inputs (name, description) showing live WP defaults as placeholders, read-only publication URL + AT-URI once written. Info notice on subdir installs.
- **Editor sidebar** — "Also publish as a standard.site document" toggle below "Share to Bluesky"; disabled with a contextual hint when the feature isn't available (subdir, global off, broken connection).
- **`useSettings`** — `useEntityProp` for both new settings, with the same loading-spinner pattern landed in #46.

## Test plan

- [x] `vendor/bin/codecept run wpunit` — **63 tests / 136 assertions, all green** (includes new `Standard\PublicationTest`, `Standard\DocumentTest`, `Standard\VerificationTest`, plus extended `UtilsTest`).
- [x] `npm run build` — clean.
- [x] `vendor/bin/phpcs` — clean.
- [x] **End-to-end on the real install**: enable global toggle, set both per-post toggles, publish a post. Log shows the full chain in order:
  - `Scheduling share for post …`
  - `Processing share for post …`
  - `[Success] Shared post … to Bluesky: https://bsky.app/…`
  - `[Success] Created standard.site publication record at at://…/site.standard.publication/3mn5fekab4e2f` (one-time on first publish)
  - `[Success] Published standard.site document for post … at at://…/site.standard.document/3mn5feky6ws24`
- [x] `GET /.well-known/site.standard.publication` returns the plain-text publication AT-URI.
- [x] Singular post head contains `<link rel="site.standard.document" href="at://…">`.
- [x] Changing site title fires the reactive sync (fingerprint changes; restoring title restores fingerprint).
- [ ] Manual check on a subdir install (skipped — covered by the unit guard).

