### PR TITLE
Update tested WordPress version to 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: danielpost
 Tags: social, bluesky, auto, share, post
 Stable tag: 1.0.0
 Requires at least: 6.6
-Tested up to: 6.8
+Tested up to: 7.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- Update the WordPress.org readme compatibility metadata to mark the plugin as tested up to WordPress 7.0.

## Testing
- Not run; metadata-only change.