### PR TITLE
Fix standard.site associated refs

### DIFF
--- a/includes/Bluesky.php
+++ b/includes/Bluesky.php
@@ -180,17 +180,12 @@ class Bluesky {
 			$body['record']['embed']['external']['thumb'] = $image_blob;
 		}
 
-		if ( $this->should_publish_document_for( $post_id ) ) {
-			$response = $this->create_post_with_document(
-				$post_id,
-				$post,
-				$connection,
-				$body['record'],
-				is_array( $image_blob ) ? $image_blob : null
-			);
-		} else {
-			$response = $this->api_client->create_record( $body, $connection['access_jwt'], $connection['did'] );
+		$associated_refs = $this->build_associated_refs( $post_id, is_array( $image_blob ) ? $image_blob : null, $connection );
+		if ( ! empty( $associated_refs ) ) {
+			$body['record']['embed']['external']['associatedRefs'] = $associated_refs;
 		}
+
+		$response = $this->api_client->create_record( $body, $connection['access_jwt'], $connection['did'] );
 
 		if ( is_wp_error( $response ) ) {
 			$this->log->error(
@@ -227,6 +222,18 @@ class Bluesky {
 			]
 		);
 
+		if ( ! empty( $associated_refs ) && ! empty( $response['uri'] ) && ! empty( $response['cid'] ) ) {
+			( new Standard\Document( $this->api_client, $this->log ) )->update_bsky_ref(
+				$post_id,
+				[
+					'uri' => (string) $response['uri'],
+					'cid' => (string) $response['cid'],
+				],
+				is_array( $image_blob ) ? $image_blob : null,
+				$connection
+			);
+		}
+
 		return $share;
 	}
 
@@ -242,91 +249,43 @@ class Bluesky {
 	}
 
 	/**
-	 * Create the Bluesky post and standard.site document in one atomic write.
+	 * If standard.site is enabled for this post, write the document record first
+	 * and return strongRefs that can be attached to the Bluesky post.
 	 *
-	 * The initial document cannot include bskyPostRef because the Bluesky post
-	 * CID is only known after the write. Once the atomic create succeeds, we
-	 * update the document with the document-side strongRef. The Bluesky post does
-	 * not point back at the document, avoiding an unstable CID cycle.
-	 *
-	 * @param array<string,mixed>      $connection
-	 * @param array<string,mixed>      $bsky_record
-	 * @param array<string,mixed>|null $image_blob
-	 * @return array<string,mixed>|\WP_Error
+	 * @param array<string,mixed>|null $image_blob Optional reusable cover image blob.
+	 * @param array<string,mixed>      $connection Already-refreshed connection.
+	 * @return array<int,array<string,mixed>>
 	 */
-	private function create_post_with_document( int $post_id, \WP_Post $post, array $connection, array $bsky_record, ?array $image_blob ) {
-		$publication     = new Standard\Publication( $this->api_client, $this->log );
-		$publication_uri = $publication->ensure_exists_for_connection( $connection );
-		if ( is_wp_error( $publication_uri ) ) {
-			return $publication_uri;
+	private function build_associated_refs( int $post_id, ?array $image_blob, array $connection ): array {
+		if ( ! $this->should_publish_document_for( $post_id ) ) {
+			return [];
 		}
 
-		$document = new Standard\Document( $this->api_client, $this->log, $publication );
-		$prepared = $document->prepare_record( $post_id, (string) $publication_uri, null, $image_blob );
-		if ( is_wp_error( $prepared ) ) {
-			return $prepared;
+		$document    = new Standard\Document( $this->api_client, $this->log );
+		$publication = new Standard\Publication( $this->api_client, $this->log );
+
+		$doc_ref = $document->publish( $post_id, null, $image_blob, $connection );
+		if ( is_wp_error( $doc_ref ) || empty( $doc_ref['uri'] ) || empty( $doc_ref['cid'] ) ) {
+			return [];
 		}
 
-		$result = $this->api_client->apply_writes(
+		$refs = [
 			[
-				[
-					'$type'      => 'com.atproto.repo.applyWrites#create',
-					'collection' => 'app.bsky.feed.post',
-					'rkey'       => $this->generate_rkey(),
-					'value'      => $bsky_record,
-				],
-				[
-					'$type'      => 'com.atproto.repo.applyWrites#create',
-					'collection' => 'site.standard.document',
-					'rkey'       => $prepared['rkey'],
-					'value'      => $prepared['record'],
-				],
+				'$type' => 'com.atproto.repo.strongRef',
+				'uri'   => $doc_ref['uri'],
+				'cid'   => $doc_ref['cid'],
 			],
-			$connection['access_jwt'],
-			$connection['did']
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		$bsky_result = $result['results'][0] ?? [];
-		$doc_result  = $result['results'][1] ?? [];
-		if ( empty( $bsky_result['uri'] ) || empty( $bsky_result['cid'] ) || empty( $doc_result['uri'] ) || empty( $doc_result['cid'] ) ) {
-			return new \WP_Error( 'autoblue_invalid_apply_writes_response', __( 'The PDS did not return complete Bluesky and document record refs.', 'autoblue' ) );
-		}
-
-		$document->store_meta( $post_id, $doc_result, $prepared['rkey'] );
-
-		$update = $document->update_bsky_ref(
-			$post_id,
-			[
-				'uri' => (string) $bsky_result['uri'],
-				'cid' => (string) $bsky_result['cid'],
-			],
-			$image_blob,
-			$connection
-		);
-
-		if ( is_wp_error( $update ) ) {
-			$this->log->error(
-				__( 'Failed to add bskyPostRef to standard.site document for post `{post_title}` with ID `{post_id}`: {message}', 'autoblue' ),
-				[
-					'post_id'    => $post_id,
-					'post_title' => $post->post_title,
-					'message'    => $update->get_error_message(),
-				]
-			);
-		}
-
-		return [
-			'uri'         => (string) $bsky_result['uri'],
-			'cid'         => (string) $bsky_result['cid'],
-			'applyWrites' => $result,
 		];
-	}
 
-	private function generate_rkey(): string {
-		return 'ab' . strtolower( str_replace( '-', '', wp_generate_uuid4() ) );
+		$pub_ref = $publication->get_strongref();
+		if ( $pub_ref ) {
+			$refs[] = [
+				'$type' => 'com.atproto.repo.strongRef',
+				'uri'   => $pub_ref['uri'],
+				'cid'   => $pub_ref['cid'],
+			];
+		}
+
+		return $refs;
 	}
 }

--- a/includes/Standard/Document.php
+++ b/includes/Standard/Document.php
@@ -37,9 +37,11 @@ class Document {
 	 *        the bsky post can embed it via app.bsky.embed.record).
 	 * @param array<string,mixed>|null              $cover_blob_ref
 	 *        Optional reusable blob ref from the bsky post upload.
+	 * @param array<string,mixed>|null              $connection
+	 *        Optional already-refreshed connection.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function publish( int $post_id, ?array $bsky_post_ref, ?array $cover_blob_ref = null ) {
+	public function publish( int $post_id, ?array $bsky_post_ref, ?array $cover_blob_ref = null, ?array $connection = null ) {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
@@ -49,7 +51,14 @@ class Document {
 			return new \WP_Error( 'autoblue_document_invalid_bsky_ref', __( 'A Bluesky post URI and CID are required.', 'autoblue' ) );
 		}
 
-		$publication_uri = $this->publication->ensure_exists();
+		if ( null === $connection ) {
+			$connection = $this->get_active_connection();
+			if ( is_wp_error( $connection ) ) {
+				return $connection;
+			}
+		}
+
+		$publication_uri = $this->publication->ensure_exists_for_connection( $connection );
 		if ( is_wp_error( $publication_uri ) ) {
 			$this->log->error(
 				__( 'Skipping standard.site document for post `{post_title}` with ID `{post_id}`: publication unavailable.', 'autoblue' ),
@@ -62,19 +71,12 @@ class Document {
 			return $publication_uri;
 		}
 
-		$connection = $this->get_active_connection();
-		if ( is_wp_error( $connection ) ) {
-			return $connection;
-		}
-
 		$record = $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref );
-		$rkey   = $this->get_rkey( $post_id );
 
 		$response = $this->api_client->create_record(
 			[
 				'repo'       => $connection['did'],
 				'collection' => self::COLLECTION,
-				'rkey'       => $rkey,
 				'record'     => $record,
 			],
 			$connection['access_jwt'],
@@ -97,7 +99,13 @@ class Document {
 			return new \WP_Error( 'autoblue_invalid_document_response', __( 'Document record was created but no URI was returned.', 'autoblue' ) );
 		}
 
-		$stored = $this->store_meta( $post_id, $response, $rkey );
+		$stored = [
+			'uri'  => (string) $response['uri'],
+			'cid'  => (string) ( $response['cid'] ?? '' ),
+			'rkey' => $this->extract_rkey( (string) $response['uri'] ),
+		];
+
+		update_post_meta( $post_id, self::META_KEY, $stored );
 
 		$this->log->success(
 			__( 'Published standard.site document for post `{post_title}` with ID `{post_id}` at {uri}.', 'autoblue' ),
@@ -109,67 +117,6 @@ class Document {
 		);
 
 		return $stored;
-	}
-
-	/**
-	 * Prepare the document record for an external batch write.
-	 *
-	 * @param array{uri:string,cid:string}|null $bsky_post_ref
-	 * @param array<string,mixed>|null          $cover_blob_ref
-	 * @return array{rkey:string,record:array<string,mixed>}|\WP_Error
-	 */
-	public function prepare_record( int $post_id, string $publication_uri, ?array $bsky_post_ref, ?array $cover_blob_ref = null ) {
-		$post = get_post( $post_id );
-		if ( ! $post ) {
-			return new \WP_Error( 'autoblue_document_post_not_found', __( 'Post not found.', 'autoblue' ) );
-		}
-
-		if ( null !== $bsky_post_ref && ( empty( $bsky_post_ref['uri'] ) || empty( $bsky_post_ref['cid'] ) ) ) {
-			return new \WP_Error( 'autoblue_document_invalid_bsky_ref', __( 'A Bluesky post URI and CID are required.', 'autoblue' ) );
-		}
-
-		return [
-			'rkey'   => $this->get_rkey( $post_id ),
-			'record' => $this->build_record( $post, $publication_uri, $bsky_post_ref, $cover_blob_ref ),
-		];
-	}
-
-	/**
-	 * Persist document metadata from a PDS write response.
-	 *
-	 * @param array<string,mixed> $response
-	 * @return array{uri:string,cid:string,rkey:string}
-	 */
-	public function store_meta( int $post_id, array $response, ?string $rkey = null ): array {
-		$uri    = (string) ( $response['uri'] ?? '' );
-		$stored = [
-			'uri'  => $uri,
-			'cid'  => (string) ( $response['cid'] ?? '' ),
-			'rkey' => $rkey ?: $this->extract_rkey( $uri ),
-		];
-
-		update_post_meta( $post_id, self::META_KEY, $stored );
-
-		return $stored;
-	}
-
-	public function get_rkey( int $post_id ): string {
-		$stored = get_post_meta( $post_id, self::META_KEY, true );
-		if ( is_array( $stored ) && ! empty( $stored['rkey'] ) ) {
-			return (string) $stored['rkey'];
-		}
-
-		$rkey = 'ab' . strtolower( str_replace( '-', '', wp_generate_uuid4() ) );
-		update_post_meta(
-			$post_id,
-			self::META_KEY,
-			array_merge(
-				is_array( $stored ) ? $stored : [],
-				[ 'rkey' => $rkey ]
-			)
-		);
-
-		return $rkey;
 	}
 
 	/**

--- a/includes/Standard/Verification.php
+++ b/includes/Standard/Verification.php
@@ -16,6 +16,7 @@ class Verification {
 	public function register_hooks(): void {
 		add_action( 'parse_request', [ $this, 'maybe_serve_well_known' ] );
 		add_action( 'wp_head', [ $this, 'inject_document_link' ] );
+		add_action( 'wp_head', [ $this, 'inject_publication_link' ] );
 	}
 
 	public function maybe_serve_well_known(): void {
@@ -64,6 +65,34 @@ class Verification {
 		printf(
 			'<link rel="site.standard.document" href="%s" />' . "\n",
 			esc_attr( (string) $document['uri'] )
+		);
+	}
+
+	public function inject_publication_link(): void {
+		if ( ! is_front_page() && ! is_singular() ) {
+			return;
+		}
+
+		if ( ! is_front_page() && is_singular() ) {
+			$post_id = get_queried_object_id();
+			if ( ! $post_id ) {
+				return;
+			}
+
+			$post_type = get_post_type( $post_id );
+			if ( ! $post_type || ! in_array( $post_type, Utils::get_enabled_post_types(), true ) ) {
+				return;
+			}
+		}
+
+		$uri = ( new Publication() )->get_uri();
+		if ( ! $uri ) {
+			return;
+		}
+
+		printf(
+			'<link rel="site.standard.publication" href="%s" />' . "\n",
+			esc_attr( $uri )
 		);
 	}
 

--- a/tests/wpunit/BlueskyTest.php
+++ b/tests/wpunit/BlueskyTest.php
@@ -66,41 +66,55 @@ class BlueskyTest extends WPTestCase {
 		$this->bluesky->share_to_bluesky( $post_id );
 	}
 
-	public function test_standard_site_share_uses_atomic_apply_writes_and_document_strong_ref() {
+	public function test_standard_site_share_writes_document_before_bluesky_post_with_associated_refs() {
 		$post_id = $this->create_test_post( self::ORIGINAL_MESSAGE );
 		$this->enable_standard_site_for_post( $post_id );
 
 		$this->log_mock->shouldReceive( 'success' );
-		$this->api_mock->shouldReceive( 'apply_writes' )
+		$this->api_mock->shouldReceive( 'create_record' )
 			->once()
+			->ordered()
 			->withArgs(
 				static function ( $writes ) {
-					return count( $writes ) === 2
-						&& $writes[0]['collection'] === 'app.bsky.feed.post'
-						&& $writes[1]['collection'] === 'site.standard.document'
-						&& ! isset( $writes[0]['value']['embed']['external']['associatedRefs'] )
-						&& ! isset( $writes[1]['value']['bskyPostRef'] );
+					return $writes['collection'] === 'site.standard.document'
+						&& ! isset( $writes['rkey'] )
+						&& ! isset( $writes['record']['bskyPostRef'] );
 				}
 			)
 			->andReturn(
 				[
-					'results' => [
-						[
-							'uri' => 'at://mock-did/app.bsky.feed.post/bsky123',
-							'cid' => 'bsky-cid',
-						],
-						[
-							'uri' => 'at://mock-did/site.standard.document/doc123',
-							'cid' => 'doc-cid',
-						],
-					],
+					'uri' => 'at://mock-did/site.standard.document/doc123',
+					'cid' => 'doc-cid',
+				]
+			);
+		$this->api_mock->shouldReceive( 'create_record' )
+			->once()
+			->ordered()
+			->withArgs(
+				static function ( $body ) {
+					$refs = $body['record']['embed']['external']['associatedRefs'] ?? [];
+
+					return $body['collection'] === 'app.bsky.feed.post'
+						&& count( $refs ) === 2
+						&& $refs[0]['uri'] === 'at://mock-did/site.standard.document/doc123'
+						&& $refs[0]['cid'] === 'doc-cid'
+						&& $refs[1]['uri'] === 'at://mock-did/site.standard.publication/pub123'
+						&& $refs[1]['cid'] === 'pub-cid';
+				}
+			)
+			->andReturn(
+				[
+					'uri' => 'at://mock-did/app.bsky.feed.post/bsky123',
+					'cid' => 'bsky-cid',
 				]
 			);
 		$this->api_mock->shouldReceive( 'put_record' )
 			->once()
+			->ordered()
 			->withArgs(
 				static function ( $body ) {
 					return $body['collection'] === 'site.standard.document'
+						&& $body['rkey'] === 'doc123'
 						&& $body['record']['bskyPostRef']['uri'] === 'at://mock-did/app.bsky.feed.post/bsky123'
 						&& $body['record']['bskyPostRef']['cid'] === 'bsky-cid';
 				}
@@ -117,24 +131,44 @@ class BlueskyTest extends WPTestCase {
 
 		$this->assertSame( 'at://mock-did/app.bsky.feed.post/bsky123', $share['uri'] );
 		$this->assertSame( 'at://mock-did/site.standard.document/doc123', $doc['uri'] );
-		$this->assertSame( 'doc-cid-with-bsky-ref', $doc['cid'] );
 	}
 
-	public function test_standard_site_apply_writes_failure_does_not_store_document_uri() {
+	public function test_standard_site_bluesky_failure_leaves_created_document_for_retry_or_cleanup() {
 		$post_id = $this->create_test_post( self::ORIGINAL_MESSAGE );
 		$this->enable_standard_site_for_post( $post_id );
 
 		$this->log_mock->shouldReceive( 'error' )->once();
-		$this->api_mock->shouldReceive( 'apply_writes' )
+		$this->log_mock->shouldReceive( 'success' )->once();
+		$this->api_mock->shouldReceive( 'create_record' )
 			->once()
-			->andReturn( new \WP_Error( 'mock_apply_writes_failed', 'No records were written.' ) );
+			->ordered()
+			->withArgs(
+				static function ( $body ) {
+					return $body['collection'] === 'site.standard.document';
+				}
+			)
+			->andReturn(
+				[
+					'uri' => 'at://mock-did/site.standard.document/doc123',
+					'cid' => 'doc-cid',
+				]
+			);
+		$this->api_mock->shouldReceive( 'create_record' )
+			->once()
+			->ordered()
+			->withArgs(
+				static function ( $body ) {
+					return $body['collection'] === 'app.bsky.feed.post';
+				}
+			)
+			->andReturn( new \WP_Error( 'mock_bsky_create_failed', 'Bluesky post was not written.' ) );
 		$this->api_mock->shouldReceive( 'put_record' )->never();
 
 		$this->assertFalse( $this->bluesky->share_to_bluesky( $post_id ) );
 
 		$doc = get_post_meta( $post_id, 'autoblue_document', true );
 		$this->assertIsArray( $doc );
-		$this->assertArrayNotHasKey( 'uri', $doc );
+		$this->assertSame( 'at://mock-did/site.standard.document/doc123', $doc['uri'] );
 	}
 
 	private function create_test_post( string $original_message ): int {

--- a/tests/wpunit/Standard/VerificationTest.php
+++ b/tests/wpunit/Standard/VerificationTest.php
@@ -63,4 +63,54 @@ class VerificationTest extends WPTestCase {
 
 		$this->assertSame( '', $output );
 	}
+
+	public function test_inject_publication_link_renders_on_singular_with_publication(): void {
+		$post_id = wp_insert_post(
+			[
+				'post_title'   => 'Article',
+				'post_content' => 'Body',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			]
+		);
+		update_option(
+			'autoblue_publication_record',
+			[
+				'uri' => 'at://did:plc:testuser/site.standard.publication/pub123',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		( new Verification() )->inject_publication_link();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'rel="site.standard.publication"', $output );
+		$this->assertStringContainsString( 'at://did:plc:testuser/site.standard.publication/pub123', $output );
+	}
+
+	public function test_inject_publication_link_skipped_without_publication(): void {
+		$post_id = wp_insert_post(
+			[
+				'post_title'   => 'Article',
+				'post_content' => 'Body',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		ob_start();
+		( new Verification() )->inject_publication_link();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'autoblue_publication_record' );
+		parent::tearDown();
+	}
 }


### PR DESCRIPTION
## Summary
- restore the pre-atomic standard.site publish flow so the document is created before the Bluesky post
- attach document and publication strongRefs to embed.external.associatedRefs
- emit publication verification link tags alongside document tags

## Testing
- vendor/bin/phpcs includes/Bluesky.php includes/Standard/Document.php includes/Standard/Verification.php tests/wpunit/BlueskyTest.php tests/wpunit/Standard/VerificationTest.php
- php -d register_argc_argv=On vendor/bin/codecept run wpunit --filter 'VerificationTest|BlueskyTest'
- live-site publish test confirmed working