### PR TITLE
Release v2.0.1

### DIFF
--- a/autoblue.php
+++ b/autoblue.php
@@ -7,7 +7,7 @@
  * Author URI: https://autoblue.co
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.0
+ * Version: 2.0.1
  * Text Domain: autoblue
  * Requires at least: 6.6
  * Requires PHP: 7.4
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-define( 'AUTOBLUE_VERSION', '2.0.0' );
+define( 'AUTOBLUE_VERSION', '2.0.1' );
 define( 'AUTOBLUE_SLUG', 'autoblue' );
 define( 'AUTOBLUE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'AUTOBLUE_PATH', plugin_dir_path( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Autoblue ===
 Contributors: danielpost
 Tags: social, bluesky, auto, share, post
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 Requires at least: 6.6
 Tested up to: 7.0
 Requires PHP: 7.4
@@ -45,6 +45,9 @@ Currently, Autoblue only works in the block editor. It uses a lot of modern Word
 3. Keep track of everything that Autoblue does.
 
 == Changelog ==
+
+= 2.0.1 =
+* Fix: Restore enhanced standard.site Bluesky link cards by attaching document and publication references correctly.
 
 = 2.0.0 =
 * Feature: Publish posts as standard.site document records on your AT Protocol PDS.


### PR DESCRIPTION
## Summary
- bump Autoblue to 2.0.1
- update the WordPress.org stable tag
- add the 2.0.1 changelog entry for the standard.site associated refs fix

## Testing
- vendor/bin/phpcs autoblue.php